### PR TITLE
feat: add kid-friendly chess academy module

### DIFF
--- a/backend/features/chess_academy/__init__.py
+++ b/backend/features/chess_academy/__init__.py
@@ -1,0 +1,1 @@
+"""Chess Academy feature package."""

--- a/backend/features/chess_academy/router.py
+++ b/backend/features/chess_academy/router.py
@@ -1,0 +1,633 @@
+"""Chess Academy feature router.
+
+Provides endpoints that power the kid-friendly chess training module.  The
+endpoints expose move validation, AI move calculation with multiple difficulty
+levels, hint generation, and curated practice puzzles.  The implementation is
+fully self-contained so that it does not interfere with other backend modules.
+"""
+from __future__ import annotations
+
+import math
+import random
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+import chess
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+router = APIRouter(prefix="/chess", tags=["Chess Academy"])
+
+CHECKMATE_SCORE = 100_000
+STARTING_FEN = chess.STARTING_FEN
+
+PIECE_VALUES: Dict[chess.PieceType, int] = {
+    chess.PAWN: 100,
+    chess.KNIGHT: 320,
+    chess.BISHOP: 330,
+    chess.ROOK: 500,
+    chess.QUEEN: 900,
+    chess.KING: 20_000,
+}
+
+# Simplified piece-square tables that gently nudge the AI to develop pieces and
+# value center control.  Values are expressed from White's perspective and are
+# mirrored for Black pieces at runtime.
+PAWN_TABLE = [
+    0, 0, 0, 0, 0, 0, 0, 0,
+    50, 50, 50, 50, 50, 50, 50, 50,
+    10, 10, 20, 30, 30, 20, 10, 10,
+    5, 5, 10, 25, 25, 10, 5, 5,
+    0, 0, 0, 20, 20, 0, 0, 0,
+    5, -5, -10, 0, 0, -10, -5, 5,
+    5, 10, 10, -20, -20, 10, 10, 5,
+    0, 0, 0, 0, 0, 0, 0, 0,
+]
+KNIGHT_TABLE = [
+    -50, -40, -30, -30, -30, -30, -40, -50,
+    -40, -20, 0, 0, 0, 0, -20, -40,
+    -30, 0, 10, 15, 15, 10, 0, -30,
+    -30, 5, 15, 20, 20, 15, 5, -30,
+    -30, 0, 15, 20, 20, 15, 0, -30,
+    -30, 5, 10, 15, 15, 10, 5, -30,
+    -40, -20, 0, 5, 5, 0, -20, -40,
+    -50, -40, -30, -30, -30, -30, -40, -50,
+]
+BISHOP_TABLE = [
+    -20, -10, -10, -10, -10, -10, -10, -20,
+    -10, 5, 0, 0, 0, 0, 5, -10,
+    -10, 10, 10, 10, 10, 10, 10, -10,
+    -10, 0, 10, 10, 10, 10, 0, -10,
+    -10, 5, 5, 10, 10, 5, 5, -10,
+    -10, 0, 5, 10, 10, 5, 0, -10,
+    -10, 0, 0, 0, 0, 0, 0, -10,
+    -20, -10, -10, -10, -10, -10, -10, -20,
+]
+ROOK_TABLE = [
+    0, 0, 5, 10, 10, 5, 0, 0,
+    -5, 0, 0, 0, 0, 0, 0, -5,
+    -5, 0, 0, 0, 0, 0, 0, -5,
+    -5, 0, 0, 0, 0, 0, 0, -5,
+    -5, 0, 0, 0, 0, 0, 0, -5,
+    -5, 0, 0, 0, 0, 0, 0, -5,
+    5, 10, 10, 10, 10, 10, 10, 5,
+    0, 0, 0, 0, 0, 0, 0, 0,
+]
+QUEEN_TABLE = [
+    -20, -10, -10, -5, -5, -10, -10, -20,
+    -10, 0, 0, 0, 0, 0, 0, -10,
+    -10, 0, 5, 5, 5, 5, 0, -10,
+    -5, 0, 5, 5, 5, 5, 0, -5,
+    0, 0, 5, 5, 5, 5, 0, -5,
+    -10, 5, 5, 5, 5, 5, 0, -10,
+    -10, 0, 5, 0, 0, 0, 0, -10,
+    -20, -10, -10, -5, -5, -10, -10, -20,
+]
+KING_TABLE_MID = [
+    20, 30, 10, 0, 0, 10, 30, 20,
+    20, 20, 0, 0, 0, 0, 20, 20,
+    -10, -20, -20, -20, -20, -20, -20, -10,
+    -20, -30, -30, -40, -40, -30, -30, -20,
+    -30, -40, -40, -50, -50, -40, -40, -30,
+    -30, -40, -40, -50, -50, -40, -40, -30,
+    -30, -40, -40, -50, -50, -40, -40, -30,
+    -30, -40, -40, -50, -50, -40, -40, -30,
+]
+KING_TABLE_END = [
+    -50, -40, -30, -20, -20, -30, -40, -50,
+    -30, -20, -10, 0, 0, -10, -20, -30,
+    -30, -10, 20, 30, 30, 20, -10, -30,
+    -30, -10, 30, 40, 40, 30, -10, -30,
+    -30, -10, 30, 40, 40, 30, -10, -30,
+    -30, -10, 20, 30, 30, 20, -10, -30,
+    -30, -30, 0, 0, 0, 0, -30, -30,
+    -50, -30, -30, -30, -30, -30, -30, -50,
+]
+
+TABLE_LOOKUP = {
+    chess.PAWN: PAWN_TABLE,
+    chess.KNIGHT: KNIGHT_TABLE,
+    chess.BISHOP: BISHOP_TABLE,
+    chess.ROOK: ROOK_TABLE,
+    chess.QUEEN: QUEEN_TABLE,
+}
+
+CENTER_SQUARES = {chess.D4, chess.E4, chess.D5, chess.E5}
+
+DIFFICULTY_SETTINGS = {
+    "explorer": {"depth": 1, "max_random_moves": 0.6},
+    "beginner": {"depth": 1, "max_random_moves": 0.4},
+    "intermediate": {"depth": 2, "max_random_moves": 0.1},
+    "advanced": {"depth": 3, "max_random_moves": 0.0},
+}
+
+COACH_TIPS = {
+    "opening": [
+        "开局时试着让两个小兵走到中心，棋盘会更好玩喔！",
+        "记得先发展骑士和主教，它们就像你的探索队。",
+        "别急着动皇后，先让小伙伴们帮忙打开道路。",
+    ],
+    "middle": [
+        "注意保护国王，可以试着进行王车易位。",
+        "看一看对方的棋子在攻击哪里，计划好下一步。",
+        "把棋子放在中心，它们会变得更有力量！",
+    ],
+    "endgame": [
+        "进入残局时，国王也可以成为勇敢的冒险家。",
+        "记得把兵推进去，如果能升变成皇后就太棒啦！",
+        "试着用皇后加国王合作，让对手没有落脚地。",
+    ],
+}
+
+
+@dataclass
+class MoveScore:
+    move: chess.Move
+    score: float
+
+
+class FenRequest(BaseModel):
+    fen: str = Field(..., title="Forsyth-Edwards Notation", min_length=1)
+
+
+class LegalMovesRequest(FenRequest):
+    square: str = Field(..., regex=r"^[a-h][1-8]$", description="Square in algebraic notation")
+
+
+class MoveRequest(FenRequest):
+    move: str = Field(..., regex=r"^[a-h][1-8][a-h][1-8][qrbn]?$")
+    promotion: Optional[str] = Field(None, regex=r"^[qrbn]$")
+
+
+class AIMoveRequest(FenRequest):
+    difficulty: str = Field("beginner", description="Difficulty label: explorer, beginner, intermediate, advanced")
+
+
+class HintRequest(FenRequest):
+    difficulty: Optional[str] = Field(None, description="Desired difficulty for the hint (defaults to board turn)")
+
+
+class PracticePuzzle(BaseModel):
+    fen: str
+    theme: str
+    side_to_move: str
+    goal: str
+    coach_tip: str
+    solution: List[str]
+
+
+class MoveInfo(BaseModel):
+    from_square: str
+    to_square: str
+    uci: str
+    san: str
+    promotion: Optional[str] = None
+    is_capture: bool = False
+    gives_check: bool = False
+    is_safe: bool = True
+
+
+class MoveOutcome(BaseModel):
+    fen: str
+    turn: str
+    move: MoveInfo
+    halfmove_clock: int
+    fullmove_number: int
+    status: Dict[str, Optional[str]]
+    evaluation: Optional[float] = None
+    message: Optional[str] = None
+
+
+class MoveCollection(BaseModel):
+    success: bool
+    side_to_move: str
+    in_check: bool
+    legal_moves: List[MoveInfo]
+    message: str
+
+
+class AIMoveResponse(BaseModel):
+    success: bool
+    difficulty: str
+    depth: int
+    move: MoveInfo
+    fen: str
+    evaluation: float
+    coach_message: str
+    status: Dict[str, Optional[str]]
+
+
+class HintResponse(BaseModel):
+    success: bool
+    hint: MoveInfo
+    evaluation: float
+    suggestion: str
+    status: Dict[str, Optional[str]]
+
+
+PRACTICE_PUZZLES: List[PracticePuzzle] = [
+    PracticePuzzle(
+        fen="8/8/8/4k3/4N3/4K3/8/8 w - - 0 1",
+        theme="一步将军",
+        side_to_move="white",
+        goal="白方先行，一步将死黑方。",
+        coach_tip="善用你的骑士和国王合作，就能像团队英雄一样解决难题！",
+        solution=["e4f6#"],
+    ),
+    PracticePuzzle(
+        fen="6k1/5ppp/8/8/4Q3/5K2/8/6q1 w - - 0 1",
+        theme="后王夹击",
+        side_to_move="white",
+        goal="白方先行，找到一步制胜的妙招。",
+        coach_tip="让皇后和国王合作，就像最佳拍档。",
+        solution=["e4e8#"],
+    ),
+    PracticePuzzle(
+        fen="8/8/8/2k5/2P5/4K3/8/8 w - - 0 1",
+        theme="兵的升变",
+        side_to_move="white",
+        goal="白方先行，让兵顺利升变并赢得比赛。",
+        coach_tip="一步一步往前走，小兵也能成为大英雄！",
+        solution=["c4c5", "c5c6", "c6c7", "c7c8Q"],
+    ),
+]
+
+
+def _board_from_fen(fen: str) -> chess.Board:
+    try:
+        board = chess.Board(fen)
+    except ValueError as exc:  # pragma: no cover - defensive guardrail
+        raise HTTPException(status_code=400, detail=f"Invalid FEN string: {exc}") from exc
+    return board
+
+
+def _mirror_square_for_black(square: chess.Square) -> int:
+    return chess.square(chess.square_file(square), 7 - chess.square_rank(square))
+
+
+def _piece_square_value(piece: chess.Piece, square: chess.Square, endgame: bool) -> int:
+    table = TABLE_LOOKUP.get(piece.piece_type)
+    if table is None:
+        # Kings are handled separately with dedicated tables.
+        if piece.piece_type == chess.KING:
+            return (KING_TABLE_END if endgame else KING_TABLE_MID)[square]
+        return 0
+
+    if piece.color == chess.WHITE:
+        return table[square]
+    return -table[_mirror_square_for_black(square)]
+
+
+def _evaluate_board(board: chess.Board) -> float:
+    if board.is_checkmate():
+        return -CHECKMATE_SCORE
+    if board.is_stalemate() or board.is_insufficient_material():
+        return 0.0
+
+    white_material = 0
+    black_material = 0
+    positional_score = 0
+
+    total_minor_pieces = len(board.pieces(chess.BISHOP, chess.WHITE)) + len(board.pieces(chess.KNIGHT, chess.WHITE)) + len(
+        board.pieces(chess.BISHOP, chess.BLACK)
+    ) + len(board.pieces(chess.KNIGHT, chess.BLACK))
+    endgame = total_minor_pieces <= 4 and (len(board.pieces(chess.QUEEN, chess.WHITE)) + len(board.pieces(chess.QUEEN, chess.BLACK))) == 0
+
+    for piece_type, value in PIECE_VALUES.items():
+        white_pieces = list(board.pieces(piece_type, chess.WHITE))
+        black_pieces = list(board.pieces(piece_type, chess.BLACK))
+        white_material += value * len(white_pieces)
+        black_material += value * len(black_pieces)
+        for square in white_pieces:
+            positional_score += _piece_square_value(chess.Piece(piece_type, chess.WHITE), square, endgame)
+        for square in black_pieces:
+            positional_score += _piece_square_value(chess.Piece(piece_type, chess.BLACK), square, endgame)
+
+    material_score = white_material - black_material
+
+    center_control = 0
+    for square in CENTER_SQUARES:
+        piece = board.piece_at(square)
+        if piece is None:
+            continue
+        if piece.color == chess.WHITE:
+            center_control += 15
+        else:
+            center_control -= 15
+
+    mobility_bonus = 5 * len(list(board.legal_moves))
+
+    king_safety = 0
+    if board.has_kingside_castling_rights(chess.WHITE) or board.has_queenside_castling_rights(chess.WHITE):
+        king_safety += 30
+    if board.has_kingside_castling_rights(chess.BLACK) or board.has_queenside_castling_rights(chess.BLACK):
+        king_safety -= 30
+
+    bishop_pair_bonus = 35 * (
+        int(len(board.pieces(chess.BISHOP, chess.WHITE)) >= 2) - int(len(board.pieces(chess.BISHOP, chess.BLACK)) >= 2)
+    )
+
+    score_from_white_perspective = (
+        material_score
+        + positional_score
+        + center_control
+        + king_safety
+        + bishop_pair_bonus
+    )
+
+    if board.turn == chess.WHITE:
+        return score_from_white_perspective + mobility_bonus
+    return -score_from_white_perspective + mobility_bonus
+
+
+def _move_order_score(board: chess.Board, move: chess.Move) -> int:
+    score = 0
+    if board.is_capture(move):
+        captured_piece = board.piece_at(move.to_square)
+        if captured_piece:
+            score += 10 * PIECE_VALUES.get(captured_piece.piece_type, 0)
+    if board.gives_check(move):
+        score += 80
+    if board.is_castling(move):
+        score += 40
+    if chess.square_name(move.to_square) in {"d4", "e4", "d5", "e5"}:
+        score += 25
+    return score
+
+
+def _negamax(board: chess.Board, depth: int, alpha: float, beta: float) -> float:
+    if depth == 0 or board.is_game_over():
+        return _evaluate_board(board)
+
+    max_eval = -math.inf
+    ordered_moves = sorted(board.legal_moves, key=lambda mv: _move_order_score(board, mv), reverse=True)
+    for move in ordered_moves:
+        board.push(move)
+        score = -_negamax(board, depth - 1, -beta, -alpha)
+        board.pop()
+        if score > max_eval:
+            max_eval = score
+        if max_eval > alpha:
+            alpha = max_eval
+        if alpha >= beta:
+            break
+    return max_eval
+
+
+def _find_best_move(board: chess.Board, depth: int) -> MoveScore:
+    alpha = -math.inf
+    beta = math.inf
+    best_move: Optional[chess.Move] = None
+    best_score = -math.inf
+
+    ordered_moves = sorted(board.legal_moves, key=lambda mv: _move_order_score(board, mv), reverse=True)
+    for move in ordered_moves:
+        board.push(move)
+        score = -_negamax(board, depth - 1, -beta, -alpha)
+        board.pop()
+        if score > best_score or best_move is None:
+            best_score = score
+            best_move = move
+        if score > alpha:
+            alpha = score
+    if best_move is None:
+        raise HTTPException(status_code=400, detail="No legal moves available. The game might be over.")
+    return MoveScore(best_move, best_score)
+
+
+def _is_move_safe(board: chess.Board, move: chess.Move) -> bool:
+    board.push(move)
+    try:
+        if board.is_check():
+            return False
+        opponent = board.turn
+        return not board.is_attacked_by(opponent, move.to_square)
+    finally:
+        board.pop()
+
+
+def _serialize_move(board: chess.Board, move: chess.Move) -> MoveInfo:
+    san = board.san(move)
+    promotion = None
+    if move.promotion:
+        promotion = chess.piece_symbol(move.promotion)
+    return MoveInfo(
+        from_square=chess.square_name(move.from_square),
+        to_square=chess.square_name(move.to_square),
+        uci=move.uci(),
+        san=san,
+        promotion=promotion,
+        is_capture=board.is_capture(move),
+        gives_check=board.gives_check(move),
+        is_safe=_is_move_safe(board, move),
+    )
+
+
+def _status_payload(board: chess.Board) -> Dict[str, Optional[str]]:
+    outcome = board.outcome()
+    status = {
+        "is_check": board.is_check(),
+        "is_checkmate": board.is_checkmate(),
+        "is_stalemate": board.is_stalemate(),
+        "is_insufficient_material": board.is_insufficient_material(),
+        "is_seventyfive_moves": board.is_seventyfive_moves(),
+        "is_fivefold_repetition": board.is_fivefold_repetition(),
+        "winner": None,
+        "result": None,
+    }
+    if outcome:
+        status["winner"] = "white" if outcome.winner == chess.WHITE else "black" if outcome.winner == chess.BLACK else "draw"
+        status["result"] = outcome.result()
+    return status
+
+
+def _coach_message(board: chess.Board) -> str:
+    total_moves = board.fullmove_number
+    if total_moves <= 10:
+        return random.choice(COACH_TIPS["opening"])
+    if total_moves <= 25:
+        return random.choice(COACH_TIPS["middle"])
+    return random.choice(COACH_TIPS["endgame"])
+
+
+def _difficulty_from_label(label: str) -> Tuple[str, Dict[str, float]]:
+    canonical = label.lower().strip()
+    if canonical not in DIFFICULTY_SETTINGS:
+        raise HTTPException(status_code=400, detail=f"Unknown difficulty '{label}'. Choose from {', '.join(DIFFICULTY_SETTINGS)}")
+    return canonical, DIFFICULTY_SETTINGS[canonical]
+
+
+def _choose_beginner_move(board: chess.Board, randomness: float) -> MoveScore:
+    moves = list(board.legal_moves)
+    random.shuffle(moves)
+    safe_moves: List[chess.Move] = []
+    smart_moves: List[Tuple[chess.Move, float]] = []
+    for move in moves:
+        safety = _is_move_safe(board, move)
+        board.push(move)
+        score = -_evaluate_board(board)
+        board.pop()
+        if safety:
+            safe_moves.append(move)
+            smart_moves.append((move, score))
+        else:
+            smart_moves.append((move, score - 150))
+
+    if safe_moves and random.random() > randomness:
+        best_safe = max(safe_moves, key=lambda mv: _move_order_score(board, mv))
+        board.push(best_safe)
+        score = -_evaluate_board(board)
+        board.pop()
+        return MoveScore(best_safe, score)
+
+    # Fallback to the highest scoring move according to our evaluation.
+    chosen_move, best_score = max(smart_moves, key=lambda item: item[1])
+    return MoveScore(chosen_move, best_score)
+
+
+@router.get("/new-game", response_model=MoveOutcome)
+def start_new_game() -> MoveOutcome:
+    board = chess.Board()
+    first_move = MoveInfo(
+        from_square="", to_square="", uci="", san="", promotion=None, is_capture=False, gives_check=False, is_safe=True
+    )
+    return MoveOutcome(
+        fen=board.fen(),
+        turn="white",
+        move=first_move,
+        halfmove_clock=board.halfmove_clock,
+        fullmove_number=board.fullmove_number,
+        status=_status_payload(board),
+        evaluation=_evaluate_board(board),
+        message="新的一局已经准备好啦！请选择难度，然后开始你的第一步冒险。",
+    )
+
+
+@router.post("/legal-moves", response_model=MoveCollection)
+def legal_moves(payload: LegalMovesRequest) -> MoveCollection:
+    board = _board_from_fen(payload.fen)
+    if board.is_game_over():
+        raise HTTPException(status_code=400, detail="Game is already over. Start a new game to continue playing.")
+
+    square = chess.parse_square(payload.square)
+    if board.piece_at(square) is None:
+        raise HTTPException(status_code=404, detail="There is no piece on the selected square.")
+    if board.piece_at(square).color != board.turn:
+        raise HTTPException(status_code=400, detail="It's not that piece's turn to move.")
+
+    moves = [mv for mv in board.legal_moves if mv.from_square == square]
+    serialized = [_serialize_move(board, mv) for mv in moves]
+    message = (
+        "这里是可行走法，点击亮起的格子就能完成移动。"
+        if serialized
+        else "这个棋子现在不能移动，换一个试试吧。"
+    )
+    return MoveCollection(
+        success=True,
+        side_to_move="white" if board.turn == chess.WHITE else "black",
+        in_check=board.is_check(),
+        legal_moves=serialized,
+        message=message,
+    )
+
+
+@router.post("/apply-move", response_model=MoveOutcome)
+def apply_move(payload: MoveRequest) -> MoveOutcome:
+    board = _board_from_fen(payload.fen)
+    try:
+        move = chess.Move.from_uci(payload.move)
+    except ValueError as exc:  # pragma: no cover - defensive guardrail
+        raise HTTPException(status_code=400, detail="Invalid move encoding.") from exc
+
+    if payload.promotion and not move.promotion:
+        move = chess.Move.from_uci(payload.move[:4] + payload.promotion)
+    if move not in board.legal_moves:
+        raise HTTPException(status_code=400, detail="Illegal move for the current board state.")
+
+    move_info = _serialize_move(board, move)
+    board.push(move)
+
+    status = _status_payload(board)
+    evaluation = _evaluate_board(board)
+    next_turn = "white" if board.turn == chess.WHITE else "black"
+    message = _coach_message(board)
+
+    return MoveOutcome(
+        fen=board.fen(),
+        turn=next_turn,
+        move=move_info,
+        halfmove_clock=board.halfmove_clock,
+        fullmove_number=board.fullmove_number,
+        status=status,
+        evaluation=evaluation,
+        message=message,
+    )
+
+
+@router.post("/ai-move", response_model=AIMoveResponse)
+def ai_move(payload: AIMoveRequest) -> AIMoveResponse:
+    board = _board_from_fen(payload.fen)
+    if board.is_game_over():
+        raise HTTPException(status_code=400, detail="Game is already finished. No moves available.")
+
+    label, settings = _difficulty_from_label(payload.difficulty)
+    randomness = settings.get("max_random_moves", 0.0)
+    depth = settings.get("depth", 1)
+
+    if label in {"explorer", "beginner"} and random.random() < randomness:
+        choice = _choose_beginner_move(board, randomness)
+    else:
+        choice = _find_best_move(board, depth)
+
+    move_info = _serialize_move(board, choice.move)
+    board.push(choice.move)
+    status = _status_payload(board)
+    evaluation = _evaluate_board(board)
+
+    coach_message = _coach_message(board)
+    if status.get("is_checkmate"):
+        coach_message = "太棒啦！这是致胜一击。再来一局挑战自己吧！"
+
+    return AIMoveResponse(
+        success=True,
+        difficulty=label,
+        depth=depth,
+        move=move_info,
+        fen=board.fen(),
+        evaluation=evaluation,
+        coach_message=coach_message,
+        status=status,
+    )
+
+
+@router.post("/hint", response_model=HintResponse)
+def hint(payload: HintRequest) -> HintResponse:
+    board = _board_from_fen(payload.fen)
+    if board.is_game_over():
+        raise HTTPException(status_code=400, detail="Game is already finished.")
+
+    difficulty_label = payload.difficulty or ("advanced" if board.fullmove_number > 20 else "intermediate")
+    label, settings = _difficulty_from_label(difficulty_label)
+    depth = max(1, settings.get("depth", 1))
+
+    suggestion = _find_best_move(board, depth)
+    move_info = _serialize_move(board, suggestion.move)
+    status = _status_payload(board)
+    evaluation = suggestion.score
+    guidance = (
+        "这个走法可以守住你的国王并准备反击，试试看！"
+        if label in {"explorer", "beginner"}
+        else "这是当前最聪明的计划，可以帮助你获得更好的局面。"
+    )
+    return HintResponse(
+        success=True,
+        hint=move_info,
+        evaluation=evaluation,
+        suggestion=guidance,
+        status=status,
+    )
+
+
+@router.get("/practice-puzzle", response_model=PracticePuzzle)
+def practice_puzzle() -> PracticePuzzle:
+    return random.choice(PRACTICE_PUZZLES)

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,6 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 # --- 静态导入所有功能模块的路由 ---
 from features.core_api.router import router as core_api_router
 from features.doc_converter.router import router as doc_converter_router
+from features.chess_academy.router import router as chess_academy_router
 # ==============================================================================
 # [示例] 如何添加新的功能模块
 # ------------------------------------------------------------------------------
@@ -54,6 +55,8 @@ app.include_router(core_api_router, prefix="/api")
 print("✅ Successfully loaded feature: core_api")
 app.include_router(doc_converter_router, prefix="/api") # <-- 添加此行
 print("✅ Successfully loaded feature: doc_converter")
+app.include_router(chess_academy_router, prefix="/api")
+print("✅ Successfully loaded feature: chess_academy")
 
 # ==============================================================================
 # [示例] 如何注册新的功能模块路由

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -35,4 +35,5 @@ dashscope
 python-dotenv
 pdf2image
 Pillow
+python-chess==1.999
 

--- a/frontend/config.js
+++ b/frontend/config.js
@@ -60,6 +60,12 @@ const FEATURES = [
         isFullPath: true
     },
     {
+        path: 'chess-academy/index.html',
+        name: '♟️ 星空儿童国际象棋学院',
+        description: '面向小学生的国际象棋学习和对弈模块，包含智能棋友、友好提示与每日谜题。',
+        isFullPath: true
+    },
+    {
         path: 'doc-converter/index.html', // 路径相对于 frontend/features/
         name: '高性能文档转换器',
         description: '上传PDF, DOCX等多种文档，通过基础或AI增强引擎，将其转换为Markdown或CSV格式。',

--- a/frontend/features/chess-academy/index.html
+++ b/frontend/features/chess-academy/index.html
@@ -1,0 +1,440 @@
+<!DOCTYPE html>
+<html lang="zh-Hans">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>♟️ 星空儿童国际象棋学院</title>
+    <link rel="stylesheet" href="../../style.css">
+    <style>
+        :root {
+            --academy-purple: #6c63ff;
+            --academy-yellow: #ffd166;
+            --academy-green: #06d6a0;
+            --academy-sky: #80d8ff;
+            --academy-surface: #f7f9ff;
+        }
+        body {
+            background: linear-gradient(180deg, #eef5ff 0%, #ffffff 60%);
+        }
+        .academy-container {
+            max-width: 1200px;
+            margin: 0 auto;
+            padding: 32px 20px 64px;
+            color: #1f2933;
+            font-family: 'PingFang SC', 'Hiragino Sans GB', 'Microsoft YaHei', sans-serif;
+        }
+        .academy-hero {
+            background: linear-gradient(135deg, rgba(108, 99, 255, 0.15), rgba(128, 216, 255, 0.18));
+            border-radius: 32px;
+            padding: 28px;
+            box-shadow: 0 18px 40px rgba(108, 99, 255, 0.12);
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+            margin-bottom: 28px;
+        }
+        .academy-hero h1 {
+            font-size: 2.4rem;
+            margin: 0;
+            color: var(--academy-purple);
+            display: flex;
+            align-items: center;
+            gap: 12px;
+        }
+        .academy-hero h1 span {
+            font-size: 2.8rem;
+        }
+        .academy-hero p {
+            margin: 0;
+            font-size: 1.08rem;
+            line-height: 1.6;
+        }
+        .tagline {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 6px 16px;
+            border-radius: 999px;
+            background-color: rgba(6, 214, 160, 0.15);
+            color: #0a7a5b;
+            font-weight: 600;
+            width: fit-content;
+        }
+        .controls-panel {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 16px;
+            margin-bottom: 24px;
+        }
+        .panel-card {
+            background: white;
+            border-radius: 18px;
+            padding: 18px 20px;
+            box-shadow: 0 12px 28px rgba(31, 41, 51, 0.08);
+            border: 2px solid rgba(108, 99, 255, 0.1);
+        }
+        .panel-card h2 {
+            margin-top: 0;
+            font-size: 1.1rem;
+            color: #344055;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+        .panel-card label,
+        .panel-card p {
+            font-size: 0.96rem;
+            line-height: 1.5;
+        }
+        .panel-card .button-row {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin-top: 12px;
+        }
+        button.primary {
+            background: var(--academy-purple);
+            border: none;
+            color: white;
+            padding: 10px 18px;
+            border-radius: 999px;
+            font-weight: 600;
+            cursor: pointer;
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            box-shadow: 0 10px 18px rgba(108, 99, 255, 0.25);
+        }
+        button.secondary {
+            background: white;
+            border: 2px solid var(--academy-sky);
+            color: #1f2933;
+            padding: 8px 16px;
+            border-radius: 999px;
+            font-weight: 600;
+            cursor: pointer;
+            display: inline-flex;
+            gap: 6px;
+            align-items: center;
+        }
+        button.secondary.active {
+            background: var(--academy-sky);
+        }
+        button:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+        .board-wrapper {
+            display: grid;
+            grid-template-columns: minmax(0, 1fr) 320px;
+            gap: 24px;
+            align-items: flex-start;
+        }
+        .board-area {
+            background: white;
+            border-radius: 28px;
+            padding: 24px;
+            box-shadow: 0 16px 32px rgba(31, 41, 51, 0.12);
+        }
+        .board {
+            display: grid;
+            grid-template-columns: repeat(8, minmax(0, 1fr));
+            border-radius: 18px;
+            overflow: hidden;
+            border: 6px solid #1f2933;
+            aspect-ratio: 1 / 1;
+            user-select: none;
+        }
+        .square {
+            position: relative;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            font-size: clamp(28px, 4vw, 46px);
+            font-weight: 600;
+            transition: transform 0.2s ease, background 0.2s ease;
+        }
+        .square[data-color="light"] {
+            background: #fefbf6;
+        }
+        .square[data-color="dark"] {
+            background: #f7d6bf;
+        }
+        .square.highlight-move::after {
+            content: '';
+            position: absolute;
+            width: 22px;
+            height: 22px;
+            border-radius: 50%;
+            background: rgba(108, 99, 255, 0.6);
+            box-shadow: 0 0 0 6px rgba(108, 99, 255, 0.2);
+        }
+        .square.highlight-capture {
+            box-shadow: inset 0 0 0 6px rgba(255, 99, 132, 0.6);
+        }
+        .square.selected {
+            outline: 4px solid var(--academy-green);
+            transform: scale(1.04);
+        }
+        .square.in-check {
+            animation: pulse 1s infinite;
+            background: #ffadad;
+        }
+        @keyframes pulse {
+            0% { box-shadow: 0 0 0 0 rgba(255, 51, 102, 0.4); }
+            70% { box-shadow: 0 0 0 12px rgba(255, 51, 102, 0); }
+            100% { box-shadow: 0 0 0 0 rgba(255, 51, 102, 0); }
+        }
+        .side-panel {
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+        }
+        .coach-card,
+        .status-card,
+        .history-card,
+        .puzzle-card {
+            background: white;
+            border-radius: 20px;
+            padding: 18px 20px;
+            box-shadow: 0 12px 24px rgba(31, 41, 51, 0.1);
+        }
+        .coach-card h3,
+        .status-card h3,
+        .history-card h3,
+        .puzzle-card h3 {
+            margin-top: 0;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 1.1rem;
+        }
+        .coach-voice {
+            background: rgba(255, 209, 102, 0.25);
+            border-radius: 16px;
+            padding: 14px;
+            font-size: 0.95rem;
+            line-height: 1.6;
+        }
+        .status-grid {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 8px;
+            font-size: 0.95rem;
+        }
+        .status-pill {
+            padding: 8px 10px;
+            background: rgba(128, 216, 255, 0.25);
+            border-radius: 12px;
+            font-weight: 600;
+            text-align: center;
+        }
+        .history-list {
+            max-height: 220px;
+            overflow-y: auto;
+            padding-left: 16px;
+        }
+        .history-list li {
+            font-size: 0.95rem;
+            line-height: 1.6;
+        }
+        .captured-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-top: 10px;
+            font-size: 0.95rem;
+        }
+        .captured-row span {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+        .puzzle-meta {
+            display: grid;
+            gap: 6px;
+            margin-bottom: 12px;
+            font-size: 0.95rem;
+        }
+        .puzzle-meta span {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+        }
+        .coach-actions {
+            display: flex;
+            gap: 10px;
+            margin-top: 12px;
+            flex-wrap: wrap;
+        }
+        .board-legend {
+            margin-top: 10px;
+            font-size: 0.9rem;
+            color: #5f6c7b;
+        }
+        @media (max-width: 1024px) {
+            .board-wrapper {
+                grid-template-columns: 1fr;
+            }
+            .side-panel {
+                order: -1;
+            }
+        }
+        @media (max-width: 600px) {
+            .controls-panel {
+                grid-template-columns: 1fr;
+            }
+            .academy-hero h1 {
+                font-size: 1.8rem;
+            }
+        }
+        .board-legend.status-info { color: #475569; }
+        .board-legend.status-success { color: #0f9d58; }
+        .board-legend.status-warning { color: #f28b20; }
+        .board-legend.status-danger { color: #d93025; }
+        .square.last-move-from {
+            box-shadow: inset 0 0 0 4px rgba(255, 209, 102, 0.7);
+        }
+        .square.last-move-to {
+            box-shadow: inset 0 0 0 4px rgba(6, 214, 160, 0.7);
+        }
+        .promotion-overlay {
+            position: fixed;
+            inset: 0;
+            background: rgba(15, 23, 42, 0.55);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 24px;
+            z-index: 999;
+        }
+        .promotion-dialog {
+            background: #ffffff;
+            border-radius: 24px;
+            padding: 24px 28px;
+            width: min(360px, 90%);
+            text-align: center;
+            box-shadow: 0 24px 48px rgba(15, 23, 42, 0.22);
+        }
+        .promotion-dialog h3 {
+            margin: 0;
+            color: var(--academy-purple);
+            font-size: 1.2rem;
+        }
+        .promotion-dialog p {
+            margin: 8px 0 16px;
+            color: #475569;
+        }
+        .promotion-options {
+            display: grid;
+            gap: 12px;
+        }
+        .promotion-options button {
+            padding: 10px 16px;
+            border-radius: 999px;
+            border: none;
+            background: var(--academy-sky);
+            color: #1f2933;
+            font-weight: 600;
+            cursor: pointer;
+            box-shadow: 0 12px 22px rgba(128, 216, 255, 0.45);
+            transition: transform 0.2s ease;
+        }
+        .promotion-options button:hover {
+            transform: translateY(-1px);
+        }
+
+    </style>
+</head>
+<body>
+    <div class="academy-container">
+        <section class="academy-hero">
+            <div class="tagline">🌟 小小棋手成长营 · 适合零基础到高手</div>
+            <h1><span>♟️</span> 星空儿童国际象棋学院</h1>
+            <p>欢迎来到为小学生量身打造的国际象棋世界！在这里，你可以和智能棋友对战、挑战每日谜题，
+                还可以得到亲切的星际教练提示。从入门到高手，每一步都有彩虹般的鼓励与引导。</p>
+        </section>
+
+        <section class="controls-panel">
+            <div class="panel-card" id="mode-card">
+                <h2>🎯 选择你的玩法</h2>
+                <p>和智能棋友对弈，或与同桌伙伴轮流下棋。</p>
+                <div class="button-row">
+                    <button class="secondary active" data-mode="ai">🤖 智能棋友</button>
+                    <button class="secondary" data-mode="friend">🧑‍🤝‍🧑 同桌对战</button>
+                </div>
+            </div>
+            <div class="panel-card" id="difficulty-card">
+                <h2>📈 难度等级</h2>
+                <p>根据你的熟练度选择对应的星级训练。</p>
+                <div class="button-row difficulty-buttons">
+                    <button class="secondary active" data-difficulty="explorer">🌱 探索星</button>
+                    <button class="secondary" data-difficulty="beginner">🌟 新星</button>
+                    <button class="secondary" data-difficulty="intermediate">🚀 进阶</button>
+                    <button class="secondary" data-difficulty="advanced">🪐 宇宙大师</button>
+                </div>
+            </div>
+            <div class="panel-card" id="utilities-card">
+                <h2>🧰 实用工具</h2>
+                <div class="button-row">
+                    <button class="primary" id="new-game-btn">🔄 重新开局</button>
+                    <button class="secondary" id="undo-btn">↩️ 悔棋</button>
+                    <button class="secondary" id="flip-board-btn">🔁 翻转棋盘</button>
+                </div>
+                <p class="board-legend">提示：点击棋子查看可行位置，绿色外框表示已选中的棋子。</p>
+            </div>
+            <div class="panel-card" id="learning-card">
+                <h2>💡 小课堂</h2>
+                <p>随时点击“请给我提示”获取友好建议，或使用每日谜题练练脑。</p>
+                <div class="button-row coach-actions">
+                    <button class="secondary" id="hint-btn">🧠 请给我提示</button>
+                    <button class="secondary" id="puzzle-btn">🧩 每日谜题</button>
+                </div>
+            </div>
+        </section>
+
+        <section class="board-wrapper">
+            <div class="board-area">
+                <div id="status-banner" class="board-legend">正在为你准备棋盘...</div>
+                <div id="chess-board" class="board" aria-label="Chess board"></div>
+                <div class="board-legend" id="turn-indicator">轮到白方出招，加油！</div>
+            </div>
+
+            <div class="side-panel">
+                <div class="coach-card">
+                    <h3>🗣️ 星际教练</h3>
+                    <div class="coach-voice" id="coach-message">
+                        星际教练正在观察棋局，等你走出第一步就会有暖心建议。
+                    </div>
+                </div>
+                <div class="status-card">
+                    <h3>📊 对局状态</h3>
+                    <div class="status-grid" id="status-grid"></div>
+                    <div class="captured-row">
+                        <span>白方已吃子：<span id="white-captured"></span></span>
+                        <span>黑方已吃子：<span id="black-captured"></span></span>
+                    </div>
+                </div>
+                <div class="history-card">
+                    <h3>📝 着法记录</h3>
+                    <ol class="history-list" id="move-history"></ol>
+                </div>
+                <div class="puzzle-card" id="puzzle-card" style="display:none;">
+                    <h3>🧠 谜题挑战</h3>
+                    <div class="puzzle-meta" id="puzzle-meta"></div>
+                    <p id="puzzle-goal"></p>
+                    <div class="coach-actions">
+                        <button class="secondary" id="load-puzzle-btn">刷新谜题</button>
+                        <button class="secondary" id="close-puzzle-btn">关闭谜题</button>
+                    </div>
+                </div>
+            </div>
+        </section>
+    </div>
+
+    <script src="../../auth.js"></script>
+    <script src="../../models.js"></script>
+    <script src="../../usage.js"></script>
+    <script src="./script.js" type="module"></script>
+</body>
+</html>

--- a/frontend/features/chess-academy/script.js
+++ b/frontend/features/chess-academy/script.js
@@ -1,0 +1,773 @@
+checkAuth();
+
+const API_BASE = '/api/chess';
+const PIECE_GLYPHS = {
+    P: '♙', N: '♘', B: '♗', R: '♖', Q: '♕', K: '♔',
+    p: '♟︎', n: '♞', b: '♝', r: '♜', q: '♛', k: '♚'
+};
+const PIECE_NAMES = {
+    P: '白兵', N: '白马', B: '白主教', R: '白战车', Q: '白皇后', K: '白国王',
+    p: '黑兵', n: '黑马', b: '黑主教', r: '黑战车', q: '黑皇后', k: '黑国王'
+};
+const STARTING_COUNTS = {
+    P: 8, N: 2, B: 2, R: 2, Q: 1, K: 1,
+    p: 8, n: 2, b: 2, r: 2, q: 1, k: 1
+};
+
+const state = {
+    fen: '',
+    turn: 'white',
+    mode: 'ai',
+    difficulty: 'explorer',
+    moveHistory: [],
+    status: {},
+    coachMessage: '',
+    lastMove: null,
+    puzzle: null,
+    puzzleActive: false,
+    stack: [],
+};
+
+let orientation = 'white';
+let selectedSquare = null;
+let legalMoves = [];
+let interactionLocked = false;
+
+const boardElement = document.getElementById('chess-board');
+const statusBanner = document.getElementById('status-banner');
+const turnIndicator = document.getElementById('turn-indicator');
+const coachMessageEl = document.getElementById('coach-message');
+const statusGridEl = document.getElementById('status-grid');
+const moveHistoryEl = document.getElementById('move-history');
+const whiteCapturedEl = document.getElementById('white-captured');
+const blackCapturedEl = document.getElementById('black-captured');
+const puzzleCardEl = document.getElementById('puzzle-card');
+const puzzleMetaEl = document.getElementById('puzzle-meta');
+const puzzleGoalEl = document.getElementById('puzzle-goal');
+
+const modeButtons = Array.from(document.querySelectorAll('#mode-card button[data-mode]'));
+const difficultyButtons = Array.from(document.querySelectorAll('.difficulty-buttons button[data-difficulty]'));
+
+const newGameBtn = document.getElementById('new-game-btn');
+const undoBtn = document.getElementById('undo-btn');
+const flipBoardBtn = document.getElementById('flip-board-btn');
+const hintBtn = document.getElementById('hint-btn');
+const puzzleBtn = document.getElementById('puzzle-btn');
+const loadPuzzleBtn = document.getElementById('load-puzzle-btn');
+const closePuzzleBtn = document.getElementById('close-puzzle-btn');
+
+function setStatusBanner(message, tone = 'info') {
+    statusBanner.textContent = message;
+    statusBanner.className = `board-legend status-${tone}`;
+}
+
+function lockInteraction(message = '') {
+    interactionLocked = true;
+    if (message) {
+        setStatusBanner(message, 'info');
+    }
+}
+
+function unlockInteraction(message = '') {
+    interactionLocked = false;
+    if (message) {
+        setStatusBanner(message, 'info');
+    }
+}
+
+function parseFenBoard(fen) {
+    const [placement] = fen.split(' ');
+    const rows = placement.split('/');
+    return rows.map(row => {
+        const result = [];
+        for (const char of row) {
+            if (/\d/.test(char)) {
+                const empty = parseInt(char, 10);
+                for (let i = 0; i < empty; i += 1) {
+                    result.push('.');
+                }
+            } else {
+                result.push(char);
+            }
+        }
+        return result;
+    });
+}
+
+function parseFenTurn(fen) {
+    try {
+        const parts = fen.split(' ');
+        return parts[1] === 'w' ? 'white' : 'black';
+    } catch (error) {
+        console.warn('Unable to parse FEN turn', error);
+        return 'white';
+    }
+}
+
+function getPieceMap(fen) {
+    const board = parseFenBoard(fen);
+    const files = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+    const map = {};
+    for (let rankIndex = 0; rankIndex < 8; rankIndex += 1) {
+        const rankNumber = 8 - rankIndex;
+        const row = board[rankIndex];
+        for (let fileIndex = 0; fileIndex < 8; fileIndex += 1) {
+            const piece = row[fileIndex];
+            if (piece && piece !== '.') {
+                const square = `${files[fileIndex]}${rankNumber}`;
+                map[square] = piece;
+            }
+        }
+    }
+    return map;
+}
+
+function findKingSquare(fen, color) {
+    const pieceToFind = color === 'white' ? 'K' : 'k';
+    const map = getPieceMap(fen);
+    return Object.entries(map).find(([, piece]) => piece === pieceToFind)?.[0] || null;
+}
+
+function renderBoard() {
+    const board = parseFenBoard(state.fen);
+    const ranks = orientation === 'white' ? ['8', '7', '6', '5', '4', '3', '2', '1'] : ['1', '2', '3', '4', '5', '6', '7', '8'];
+    const files = orientation === 'white' ? ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'] : ['h', 'g', 'f', 'e', 'd', 'c', 'b', 'a'];
+
+    boardElement.innerHTML = '';
+
+    ranks.forEach((rank, rankIndex) => {
+        const sourceRankIndex = orientation === 'white' ? rankIndex : 7 - rankIndex;
+        const row = board[sourceRankIndex];
+        files.forEach((file, fileIndex) => {
+            const sourceFileIndex = orientation === 'white' ? fileIndex : 7 - fileIndex;
+            const piece = row[sourceFileIndex];
+            const square = document.createElement('div');
+            square.classList.add('square');
+            square.dataset.square = `${file}${rank}`;
+            square.dataset.color = (rankIndex + fileIndex) % 2 === 0 ? 'light' : 'dark';
+            if (piece && piece !== '.') {
+                square.textContent = PIECE_GLYPHS[piece] || '';
+                square.dataset.piece = piece;
+                square.title = PIECE_NAMES[piece] || '棋子';
+            } else {
+                square.textContent = '';
+                square.dataset.piece = '';
+            }
+            boardElement.appendChild(square);
+        });
+    });
+
+    highlightSpecialSquares();
+}
+
+function highlightSpecialSquares() {
+    const squares = boardElement.querySelectorAll('.square');
+    squares.forEach(square => {
+        square.classList.remove('selected', 'highlight-move', 'highlight-capture', 'in-check', 'last-move-from', 'last-move-to');
+    });
+
+    if (selectedSquare) {
+        const selectedEl = boardElement.querySelector(`[data-square="${selectedSquare}"]`);
+        if (selectedEl) {
+            selectedEl.classList.add('selected');
+        }
+    }
+
+    legalMoves.forEach(move => {
+        const target = boardElement.querySelector(`[data-square="${move.to_square}"]`);
+        if (target) {
+            target.classList.add('highlight-move');
+            if (move.is_capture) {
+                target.classList.add('highlight-capture');
+            }
+        }
+    });
+
+    if (state.lastMove) {
+        const fromEl = boardElement.querySelector(`[data-square="${state.lastMove.from_square}"]`);
+        const toEl = boardElement.querySelector(`[data-square="${state.lastMove.to_square}"]`);
+        if (fromEl) {
+            fromEl.classList.add('last-move-from');
+        }
+        if (toEl) {
+            toEl.classList.add('last-move-to');
+        }
+    }
+
+    if (state.status?.is_check) {
+        const kingSquare = findKingSquare(state.fen, state.turn);
+        if (kingSquare) {
+            const kingEl = boardElement.querySelector(`[data-square="${kingSquare}"]`);
+            if (kingEl) {
+                kingEl.classList.add('in-check');
+            }
+        }
+    }
+}
+
+function recordMove(actor, san) {
+    if (!san) {
+        return;
+    }
+    if (actor === 'white') {
+        state.moveHistory.push({
+            moveNumber: state.moveHistory.length + 1,
+            white: san,
+            black: ''
+        });
+    } else {
+        if (!state.moveHistory.length) {
+            state.moveHistory.push({ moveNumber: 1, white: '…', black: san });
+        } else {
+            state.moveHistory[state.moveHistory.length - 1].black = san;
+        }
+    }
+}
+
+function updateMoveHistory() {
+    moveHistoryEl.innerHTML = '';
+    state.moveHistory.forEach(entry => {
+        const li = document.createElement('li');
+        const parts = [];
+        parts.push(`${entry.moveNumber}.`);
+        parts.push(entry.white || '…');
+        if (entry.black) {
+            parts.push(entry.black);
+        }
+        li.textContent = parts.join(' ');
+        moveHistoryEl.appendChild(li);
+    });
+    moveHistoryEl.scrollTop = moveHistoryEl.scrollHeight;
+}
+
+function computeCapturedPieces(fen) {
+    const boardMap = getPieceMap(fen);
+    const whiteCounts = { P: 0, N: 0, B: 0, R: 0, Q: 0, K: 0 };
+    const blackCounts = { p: 0, n: 0, b: 0, r: 0, q: 0, k: 0 };
+
+    Object.values(boardMap).forEach(piece => {
+        if (piece === piece.toUpperCase()) {
+            whiteCounts[piece] += 1;
+        } else {
+            blackCounts[piece] += 1;
+        }
+    });
+
+    const capturedByWhite = { q: 0, r: 0, b: 0, n: 0, p: 0 };
+    const capturedByBlack = { Q: 0, R: 0, B: 0, N: 0, P: 0 };
+
+    Object.entries({ q: 'q', r: 'r', b: 'b', n: 'n', p: 'p' }).forEach(([key, piece]) => {
+        capturedByWhite[key] = STARTING_COUNTS[piece] - blackCounts[piece];
+    });
+    Object.entries({ Q: 'Q', R: 'R', B: 'B', N: 'N', P: 'P' }).forEach(([key, piece]) => {
+        capturedByBlack[key] = STARTING_COUNTS[piece] - whiteCounts[piece];
+    });
+
+    return { capturedByWhite, capturedByBlack };
+}
+
+function formatCaptured(map, order) {
+    const parts = [];
+    order.forEach(piece => {
+        const count = map[piece] || 0;
+        if (count > 0) {
+            const glyph = PIECE_GLYPHS[piece];
+            if (count >= 4) {
+                parts.push(`${glyph}×${count}`);
+            } else {
+                parts.push(glyph.repeat(count));
+            }
+        }
+    });
+    return parts.length ? parts.join(' ') : '暂无';
+}
+
+function updateCapturedPieces() {
+    const { capturedByWhite, capturedByBlack } = computeCapturedPieces(state.fen);
+    whiteCapturedEl.textContent = formatCaptured(capturedByWhite, ['q', 'r', 'b', 'n', 'p']);
+    blackCapturedEl.textContent = formatCaptured(capturedByBlack, ['Q', 'R', 'B', 'N', 'P']);
+}
+
+function updateCoachMessage(message) {
+    coachMessageEl.textContent = message || '星际教练正在观察棋局，等你走出第一步就会有暖心建议。';
+}
+
+function updateStatusGrid() {
+    const items = [];
+    items.push({ label: '当前轮到', value: state.turn === 'white' ? '白方' : '黑方' });
+    if (state.status?.is_checkmate) {
+        items.push({ label: '胜负结果', value: state.status.winner ? `${state.status.winner === 'white' ? '白方' : '黑方'}胜利` : '平局' });
+    } else if (state.status?.is_stalemate) {
+        items.push({ label: '局面', value: '僵局，双方平手' });
+    } else if (state.status?.is_check) {
+        items.push({ label: '警报', value: '当前一方被将军！' });
+    }
+    if (state.status?.is_insufficient_material) {
+        items.push({ label: '素材', value: '双方棋子不足以将死' });
+    }
+    if (state.puzzleActive) {
+        items.push({ label: '模式', value: '谜题挑战中' });
+    } else {
+        items.push({ label: '模式', value: state.mode === 'ai' ? '与智能棋友对战' : '同桌轮流对战' });
+    }
+
+    statusGridEl.innerHTML = '';
+    items.forEach(item => {
+        const div = document.createElement('div');
+        div.className = 'status-pill';
+        div.textContent = `${item.label}: ${item.value}`;
+        statusGridEl.appendChild(div);
+    });
+}
+
+function updateTurnIndicator() {
+    const friendly = state.turn === 'white' ? '白方' : '黑方';
+    if (state.status?.is_checkmate) {
+        turnIndicator.textContent = state.status.winner ? `${state.status.winner === 'white' ? '白方' : '黑方'}赢得胜利！` : '和棋结束。';
+    } else if (state.status?.is_stalemate) {
+        turnIndicator.textContent = '棋局僵住啦，双方握手言和。';
+    } else {
+        turnIndicator.textContent = `轮到${friendly}出招，加油！`;
+    }
+}
+
+function clearSelection() {
+    selectedSquare = null;
+    legalMoves = [];
+    highlightSpecialSquares();
+}
+
+function captureSnapshot() {
+    const snapshot = {
+        fen: state.fen,
+        turn: state.turn,
+        mode: state.mode,
+        difficulty: state.difficulty,
+        moveHistory: state.moveHistory.map(entry => ({ ...entry })),
+        status: { ...state.status },
+        coachMessage: state.coachMessage,
+        lastMove: state.lastMove ? { ...state.lastMove } : null,
+        puzzle: state.puzzle ? { ...state.puzzle } : null,
+        puzzleActive: state.puzzleActive,
+        orientation,
+    };
+    state.stack.push(snapshot);
+}
+
+function applySnapshot(snapshot) {
+    state.fen = snapshot.fen;
+    state.turn = snapshot.turn;
+    state.mode = snapshot.mode;
+    state.difficulty = snapshot.difficulty;
+    state.moveHistory = snapshot.moveHistory.map(entry => ({ ...entry }));
+    state.status = { ...snapshot.status };
+    state.coachMessage = snapshot.coachMessage;
+    state.lastMove = snapshot.lastMove ? { ...snapshot.lastMove } : null;
+    state.puzzle = snapshot.puzzle ? { ...snapshot.puzzle } : null;
+    state.puzzleActive = snapshot.puzzleActive;
+    orientation = snapshot.orientation;
+    selectedSquare = null;
+    legalMoves = [];
+    updateAll();
+}
+
+function undoLastMove() {
+    if (state.stack.length <= 1) {
+        setStatusBanner('已经回到最初的状态，无法再悔棋啦。', 'warning');
+        return;
+    }
+    state.stack.pop();
+    const snapshot = state.stack[state.stack.length - 1];
+    applySnapshot(snapshot);
+    setStatusBanner('悔棋成功，我们回到了前一步。', 'success');
+}
+
+function isGameOver() {
+    return Boolean(state.status?.is_checkmate || state.status?.is_stalemate || state.status?.winner);
+}
+
+function updateAll() {
+    renderBoard();
+    updateMoveHistory();
+    updateCapturedPieces();
+    updateCoachMessage(state.coachMessage);
+    updateStatusGrid();
+    updateTurnIndicator();
+    if (state.puzzleActive) {
+        showPuzzleCard(state.puzzle);
+    } else {
+        hidePuzzleCard();
+    }
+}
+
+async function apiGet(path) {
+    const response = await fetch(`${API_BASE}${path}`);
+    if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.detail || data.error || '请求失败');
+    }
+    return response.json();
+}
+
+async function apiPost(path, payload) {
+    const response = await fetch(`${API_BASE}${path}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+    });
+    if (!response.ok) {
+        const data = await response.json().catch(() => ({}));
+        throw new Error(data.detail || data.error || '请求失败');
+    }
+    return response.json();
+}
+
+async function startNewGame() {
+    try {
+        lockInteraction('正在设置新棋局...');
+        const data = await apiGet('/new-game');
+        state.fen = data.fen;
+        state.turn = data.turn;
+        state.status = data.status || {};
+        state.moveHistory = [];
+        state.coachMessage = data.message;
+        state.lastMove = null;
+        state.puzzle = null;
+        state.puzzleActive = false;
+        orientation = 'white';
+        state.stack = [];
+        selectedSquare = null;
+        legalMoves = [];
+        updateAll();
+        captureSnapshot();
+        unlockInteraction('新局已准备就绪，白方先行。');
+    } catch (error) {
+        console.error(error);
+        unlockInteraction('启动棋局时出现小问题，请稍后再试。');
+    }
+}
+
+function setMode(mode, { fromPuzzle = false } = {}) {
+    state.mode = mode;
+    if (!fromPuzzle) {
+        state.puzzleActive = false;
+        state.puzzle = null;
+    }
+    modeButtons.forEach(btn => {
+        btn.classList.toggle('active', btn.dataset.mode === mode);
+    });
+    updateStatusGrid();
+}
+
+function setDifficulty(level) {
+    state.difficulty = level;
+    difficultyButtons.forEach(btn => {
+        btn.classList.toggle('active', btn.dataset.difficulty === level);
+    });
+}
+
+async function requestLegalMoves(square) {
+    try {
+        lockInteraction('正在分析这个棋子的走法...');
+        const data = await apiPost('/legal-moves', { fen: state.fen, square });
+        legalMoves = data.legal_moves;
+        selectedSquare = square;
+        setStatusBanner(data.message, 'info');
+        unlockInteraction();
+        highlightSpecialSquares();
+    } catch (error) {
+        console.error(error);
+        unlockInteraction(error.message || '无法获取走法');
+        clearSelection();
+    }
+}
+
+function requiresPromotion(moveCandidates) {
+    return moveCandidates.some(move => Boolean(move.promotion));
+}
+
+function buildPromotionOverlay(color, candidates) {
+    return new Promise(resolve => {
+        const overlay = document.createElement('div');
+        overlay.className = 'promotion-overlay';
+        const dialog = document.createElement('div');
+        dialog.className = 'promotion-dialog';
+        const title = document.createElement('h3');
+        title.textContent = '选择想升变的棋子';
+        const subtitle = document.createElement('p');
+        subtitle.textContent = color === 'white' ? '白兵到达终点，可以变身啦！' : '黑兵到达终点，可以变身啦！';
+        const options = document.createElement('div');
+        options.className = 'promotion-options';
+        const promotionOrder = ['q', 'r', 'b', 'n'];
+        promotionOrder.forEach(symbol => {
+            const candidate = candidates.find(move => move.promotion === symbol) || candidates[0];
+            const btn = document.createElement('button');
+            btn.className = 'secondary';
+            btn.dataset.promotion = candidate.promotion || 'q';
+            btn.textContent = symbol === 'q' ? '变成皇后' : symbol === 'r' ? '变成战车' : symbol === 'b' ? '变成主教' : '变成骑士';
+            btn.addEventListener('click', () => {
+                document.body.removeChild(overlay);
+                resolve(candidate);
+            });
+            options.appendChild(btn);
+        });
+        dialog.appendChild(title);
+        dialog.appendChild(subtitle);
+        dialog.appendChild(options);
+        overlay.appendChild(dialog);
+        document.body.appendChild(overlay);
+    });
+}
+
+async function submitMove(moveInfo, actor) {
+    try {
+        const payload = { fen: state.fen, move: moveInfo.uci };
+        if (moveInfo.promotion) {
+            payload.promotion = moveInfo.promotion;
+        }
+        const data = await apiPost('/apply-move', payload);
+        state.fen = data.fen;
+        state.turn = data.turn;
+        state.status = data.status || {};
+        state.coachMessage = data.message || state.coachMessage;
+        state.lastMove = moveInfo;
+        recordMove(actor, moveInfo.san);
+        updateAll();
+        captureSnapshot();
+        if (typeof usageTracker !== 'undefined' && usageTracker.recordUsage) {
+            await usageTracker.recordUsage('chess-academy', 'local-engine', state.difficulty, 0, 0);
+        }
+        return data;
+    } catch (error) {
+        console.error(error);
+        setStatusBanner(error.message || '这一步似乎行不通，换个想法试试吧。', 'warning');
+        throw error;
+    }
+}
+
+async function requestAiMove() {
+    const actor = state.turn;
+    try {
+        setStatusBanner('星际棋友正在思考最聪明的走法...', 'info');
+        const data = await apiPost('/ai-move', { fen: state.fen, difficulty: state.difficulty });
+        state.fen = data.fen;
+        state.turn = parseFenTurn(data.fen);
+        state.status = data.status || {};
+        state.coachMessage = data.coach_message || state.coachMessage;
+        state.lastMove = data.move;
+        recordMove(actor, data.move.san);
+        updateAll();
+        captureSnapshot();
+        if (typeof usageTracker !== 'undefined' && usageTracker.recordUsage) {
+            await usageTracker.recordUsage('chess-academy', 'python-chess', state.difficulty, 0, 0);
+        }
+        setStatusBanner('轮到你啦，星际教练等着看你的妙手。', 'success');
+    } catch (error) {
+        console.error(error);
+        setStatusBanner(error.message || '星际棋友暂时没有回应，请再试一次。', 'warning');
+    }
+}
+
+async function handleMoveSelection(targetSquare) {
+    const candidates = legalMoves.filter(move => move.to_square === targetSquare);
+    if (!candidates.length) {
+        return;
+    }
+    let chosenMove = candidates[0];
+    if (candidates.length > 1 && requiresPromotion(candidates)) {
+        chosenMove = await buildPromotionOverlay(state.turn, candidates);
+    }
+    try {
+        lockInteraction('星际教练正在确认你的走法...');
+        const actor = state.turn;
+        const response = await submitMove(chosenMove, actor);
+        clearSelection();
+        if (state.puzzleActive) {
+            unlockInteraction('继续完成谜题目标吧！');
+            return;
+        }
+        if (state.mode === 'ai' && !isGameOver()) {
+            await requestAiMove();
+        }
+        unlockInteraction('轮到你继续规划啦！');
+    } catch (error) {
+        console.error(error);
+        unlockInteraction(error.message || '请再尝试其它走法。');
+    }
+}
+
+function squareBelongsToCurrentPlayer(piece) {
+    if (!piece) {
+        return false;
+    }
+    const isWhitePiece = piece === piece.toUpperCase();
+    return (state.turn === 'white' && isWhitePiece) || (state.turn === 'black' && !isWhitePiece);
+}
+
+async function handleSquareClick(event) {
+    if (interactionLocked) {
+        return;
+    }
+    const square = event.target.closest('.square');
+    if (!square) {
+        return;
+    }
+    const squareName = square.dataset.square;
+    if (!squareName) {
+        return;
+    }
+
+    if (selectedSquare && squareName === selectedSquare) {
+        clearSelection();
+        return;
+    }
+
+    const targetIsLegal = legalMoves.some(move => move.to_square === squareName);
+    if (selectedSquare && targetIsLegal) {
+        await handleMoveSelection(squareName);
+        return;
+    }
+
+    const piece = square.dataset.piece;
+    if (!piece) {
+        clearSelection();
+        return;
+    }
+    if (!squareBelongsToCurrentPlayer(piece)) {
+        setStatusBanner('现在轮到另一方啦，耐心等待一下。', 'warning');
+        clearSelection();
+        return;
+    }
+    await requestLegalMoves(squareName);
+}
+
+async function requestHint() {
+    try {
+        lockInteraction('星际教练正在为你观察局势...');
+        const data = await apiPost('/hint', { fen: state.fen, difficulty: state.difficulty });
+        setStatusBanner(data.suggestion, 'success');
+        legalMoves = [data.hint];
+        selectedSquare = data.hint.from_square;
+        highlightSpecialSquares();
+        updateCoachMessage(`${data.suggestion} 推荐走法：${data.hint.san}`);
+        unlockInteraction();
+    } catch (error) {
+        console.error(error);
+        unlockInteraction(error.message || '暂时无法提供提示，请稍后再试。');
+    }
+}
+
+function showPuzzleCard(puzzle) {
+    if (!puzzle) {
+        return;
+    }
+    puzzleCardEl.style.display = 'block';
+    puzzleMetaEl.innerHTML = '';
+    const theme = document.createElement('span');
+    theme.textContent = `主题：${puzzle.theme}`;
+    const side = document.createElement('span');
+    side.textContent = `先手方：${puzzle.side_to_move === 'white' ? '白方' : '黑方'}`;
+    const tip = document.createElement('span');
+    tip.textContent = `教练小贴士：${puzzle.coach_tip}`;
+    puzzleMetaEl.appendChild(theme);
+    puzzleMetaEl.appendChild(side);
+    puzzleMetaEl.appendChild(tip);
+    puzzleGoalEl.textContent = puzzle.goal;
+}
+
+function hidePuzzleCard() {
+    puzzleCardEl.style.display = 'none';
+    puzzleMetaEl.innerHTML = '';
+    puzzleGoalEl.textContent = '';
+}
+
+async function activatePuzzle() {
+    try {
+        lockInteraction('星际教练正在挑选今日谜题...');
+        const puzzle = await apiGet('/practice-puzzle');
+        state.puzzle = puzzle;
+        state.puzzleActive = true;
+        state.stack = [];
+        state.fen = puzzle.fen;
+        state.turn = parseFenTurn(puzzle.fen);
+        state.status = {};
+        state.coachMessage = puzzle.coach_tip;
+        state.moveHistory = [];
+        state.lastMove = null;
+        selectedSquare = null;
+        legalMoves = [];
+        setMode('friend', { fromPuzzle: true });
+        updateAll();
+        captureSnapshot();
+        unlockInteraction('谜题准备完毕，按照目标尝试解答吧！');
+    } catch (error) {
+        console.error(error);
+        unlockInteraction('获取谜题失败，请稍后再试。');
+    }
+}
+
+function closePuzzle() {
+    state.puzzleActive = false;
+    state.puzzle = null;
+    hidePuzzleCard();
+    setMode('ai');
+    startNewGame();
+}
+
+function attachEvents() {
+    boardElement.addEventListener('click', event => {
+        event.preventDefault();
+        handleSquareClick(event);
+    });
+    newGameBtn.addEventListener('click', () => {
+        if (interactionLocked) { return; }
+        state.puzzleActive = false;
+        state.puzzle = null;
+        hidePuzzleCard();
+        startNewGame();
+    });
+    undoBtn.addEventListener('click', () => {
+        if (interactionLocked) { return; }
+        undoLastMove();
+    });
+    flipBoardBtn.addEventListener('click', () => {
+        orientation = orientation === 'white' ? 'black' : 'white';
+        renderBoard();
+    });
+    hintBtn.addEventListener('click', () => {
+        if (interactionLocked) { return; }
+        requestHint();
+    });
+    puzzleBtn.addEventListener('click', () => {
+        if (interactionLocked) { return; }
+        activatePuzzle();
+    });
+    loadPuzzleBtn.addEventListener('click', () => {
+        if (interactionLocked) { return; }
+        activatePuzzle();
+    });
+    closePuzzleBtn.addEventListener('click', () => {
+        if (interactionLocked) { return; }
+        closePuzzle();
+    });
+    modeButtons.forEach(btn => {
+        btn.addEventListener('click', () => {
+            const mode = btn.dataset.mode;
+            setMode(mode);
+        });
+    });
+    difficultyButtons.forEach(btn => {
+        btn.addEventListener('click', () => {
+            setDifficulty(btn.dataset.difficulty);
+        });
+    });
+}
+
+async function init() {
+    attachEvents();
+    setMode(state.mode);
+    setDifficulty(state.difficulty);
+    await startNewGame();
+}
+
+init();


### PR DESCRIPTION
## Summary
- add a dedicated `chess_academy` backend feature that exposes new-game, move validation, AI move, hint, and practice puzzle endpoints powered by python-chess heuristics
- create a kid-friendly chess academy front-end with animated board, difficulty and mode controls, hints, undo, and puzzle workflows
- register the new module in the platform configuration and add the python-chess dependency so the feature stays self-contained

## Testing
- python -m compileall backend/features/chess_academy

------
https://chatgpt.com/codex/tasks/task_e_68cd17439aa48332bf7dd806312a3931