### PR TITLE
Replace deprecated Pydantic regex field arguments

### DIFF
--- a/backend/features/chess_academy/router.py
+++ b/backend/features/chess_academy/router.py
@@ -151,12 +151,12 @@ class FenRequest(BaseModel):
 
 
 class LegalMovesRequest(FenRequest):
-    square: str = Field(..., regex=r"^[a-h][1-8]$", description="Square in algebraic notation")
+    square: str = Field(..., pattern=r"^[a-h][1-8]$", description="Square in algebraic notation")
 
 
 class MoveRequest(FenRequest):
-    move: str = Field(..., regex=r"^[a-h][1-8][a-h][1-8][qrbn]?$")
-    promotion: Optional[str] = Field(None, regex=r"^[qrbn]$")
+    move: str = Field(..., pattern=r"^[a-h][1-8][a-h][1-8][qrbn]?$")
+    promotion: Optional[str] = Field(None, pattern=r"^[qrbn]$")
 
 
 class AIMoveRequest(FenRequest):


### PR DESCRIPTION
## Summary
- replace Pydantic `Field` regex arguments with `pattern` to align chess academy request models with Pydantic v2

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd69b6d2ec8332be0a854142e9108b