### PR TITLE
Add IELTS study system backend and frontend modules

### DIFF
--- a/backend/features/ielts_study_system/__init__.py
+++ b/backend/features/ielts_study_system/__init__.py
@@ -1,0 +1,3 @@
+"""IELTS study system feature package."""
+
+__all__ = ["router"]

--- a/backend/features/ielts_study_system/router.py
+++ b/backend/features/ielts_study_system/router.py
@@ -1,0 +1,757 @@
+"""FastAPI router powering the IELTS study system feature.
+
+The router exposes read-only configuration endpoints and lightweight planning
+helpers that orchestrate the IELTS listening, speaking, reading and writing
+modules.  Business logic is intentionally declarative so the feature can evolve
+without impacting other backend modules.
+"""
+from __future__ import annotations
+
+from typing import Dict, List, Literal, Optional
+
+from fastapi import APIRouter, HTTPException, Query
+from pydantic import BaseModel, Field, conint
+
+router = APIRouter(prefix="/ielts", tags=["IELTS Study System"])
+
+SkillName = Literal["listening", "speaking", "reading", "writing"]
+TARGET_BANDS = {"5.5": 5.5, "6.5": 6.5, "7.5+": 7.5}
+
+
+STAGE_LIBRARY: Dict[str, Dict[str, object]] = {
+    "foundation": {
+        "id": "foundation",
+        "label": "入门衔接",
+        "summary": "针对语言基础较弱或首次接触雅思的学习者，目标是构建稳定的语音语感和核心语法框架。",
+        "base_weeks": 6,
+        "intensity_hours": "每周 12-15 小时",
+        "skill_weights": {
+            "listening": 0.28,
+            "speaking": 0.18,
+            "reading": 0.26,
+            "writing": 0.28,
+        },
+        "skill_focus": {
+            "listening": [
+                "每日 15 分钟语音热身，建立语音辨识能力",
+                "分段精听真题录音并使用逐句播放功能反复跟读",
+                "通过自动转写比对，记录高频错词并加入生词本",
+            ],
+            "speaking": [
+                "围绕 Part1 高频话题进行 1 分钟限时输出",
+                "使用语音识别生成实时字幕，修正发音与语调",
+                "模仿高分范例的句式，积累描述性词汇",
+            ],
+            "reading": [
+                "精读短篇文章，标注核心句式与逻辑连接词",
+                "练习段落主旨题，结合即点即义功能快速查词",
+                "建立错题本，按题型记录失分原因",
+            ],
+            "writing": [
+                "拆解 Task1 数据描述框架，熟悉常用表达",
+                "以 30 分钟为单位练习小作文草稿，使用 AI 批改纠错",
+                "整理常见句式模板，完善语法基础",
+            ],
+        },
+        "milestones": [
+            "完成至少 20 条精听笔记并整理首轮生词表",
+            "掌握 8 组 Part1 高频话题的核心回答结构",
+            "完成 6 篇 Task1 草稿并获得 AI 批改评分 ≥ 5.0",
+        ],
+        "checkpoint": "通过阶段测评，四项分数均达到 5.0 左右即可转入基础夯实阶段",
+        "progress_metrics": {
+            "listening": "分段听写准确率 ≥ 70%",
+            "speaking": "语音识别正确率 ≥ 85%，语法大错≤1",
+            "reading": "词汇推断题正确率 ≥ 60%",
+            "writing": "AI 批改语法评分 ≥ 5.0",
+        },
+    },
+    "core": {
+        "id": "core",
+        "label": "基础夯实",
+        "summary": "面向 5.0-5.5 水平学习者，重点解决信息提取效率与句型多样性不足的问题。",
+        "base_weeks": 5,
+        "intensity_hours": "每周 14-16 小时",
+        "skill_weights": {
+            "listening": 0.26,
+            "speaking": 0.22,
+            "reading": 0.26,
+            "writing": 0.26,
+        },
+        "skill_focus": {
+            "listening": [
+                "以段落为单位完成精听 + 听写比对，强化信息捕捉",
+                "每周 2 次跟读练习并查看发音准确度评分",
+                "错词复盘结合 TTS 朗读，巩固拼写与语音映射",
+            ],
+            "speaking": [
+                "进入模拟考试模式，完成 Part2 2 分钟陈述",
+                "根据 AI 考官反馈调整语法与词汇多样性",
+                "积累高分连接词和衔接句，提升连贯性",
+            ],
+            "reading": [
+                "精读与略读结合，控制定位时间",
+                "使用高亮提示快速定位同义替换",
+                "针对匹配题、判断题建立专属解题流程",
+            ],
+            "writing": [
+                "每周输出 1 篇 Task2 草稿，聚焦结构与论证",
+                "比对高分范文，总结段落展开方式",
+                "扩充主题词汇表，记录可替换表达",
+            ],
+        },
+        "milestones": [
+            "完成 3 套听力真题并将错词同步至词汇手册",
+            "建立 12 个 Part2 主题的故事素材库",
+            "完成 4 套阅读精读笔记，错题分类清晰",
+        ],
+        "checkpoint": "模考分数稳定在 6.0 左右后，进入进阶突破阶段",
+        "progress_metrics": {
+            "listening": "听力 Section 2 正确率 ≥ 70%",
+            "speaking": "AI 反馈中语法错误率下降 30%",
+            "reading": "定位题平均耗时 ≤ 75 秒",
+            "writing": "Task2 逻辑结构得分 ≥ 6.0",
+        },
+    },
+    "advanced": {
+        "id": "advanced",
+        "label": "进阶突破",
+        "summary": "面向 6.0+ 学习者，聚焦难题突破与语言高级感的打造。",
+        "base_weeks": 4,
+        "intensity_hours": "每周 16-18 小时",
+        "skill_weights": {
+            "listening": 0.25,
+            "speaking": 0.25,
+            "reading": 0.25,
+            "writing": 0.25,
+        },
+        "skill_focus": {
+            "listening": [
+                "全真模考 + 精听复盘组合，锻炼注意力切换",
+                "围绕同义替换和细节捕捉建立听力笔记模板",
+                "练习高难度跟读，关注语调和断句",
+            ],
+            "speaking": [
+                "Part3 深度问答演练，突出论证深度",
+                "利用 AI 考官反馈打磨高级词汇与句型",
+                "模拟考试模式下强化时间管理与逻辑衔接",
+            ],
+            "reading": [
+                "强化段落信息比对，训练快速略读",
+                "通过错题本追踪高难题型并二次练习",
+                "拆解文章结构，积累论证框架",
+            ],
+            "writing": [
+                "Task2 全流程 40 分钟模写，提升时间掌控",
+                "针对不同题型准备替换模板和例证库",
+                "AI 批改聚焦词汇多样性与高级句式",
+            ],
+        },
+        "milestones": [
+            "连续两周保持听力 Section 3 正确率 ≥ 75%",
+            "完成 6 套口语模拟并获得流利度评分 ≥ 6.5",
+            "阅读题型错题率降至 20% 以内",
+        ],
+        "checkpoint": "模考平均分达到目标分数 -0.5，即可进入冲刺拔高阶段",
+        "progress_metrics": {
+            "listening": "困难题型（多选/地图题）正确率 ≥ 65%",
+            "speaking": "高级词汇密度 ≥ 15%",
+            "reading": "每篇文章总耗时 ≤ 18 分钟",
+            "writing": "Task2 词汇多样性评分 ≥ 6.5",
+        },
+    },
+    "sprint": {
+        "id": "sprint",
+        "label": "冲刺拔高",
+        "summary": "考试前的综合冲刺，确保状态稳定并模拟真实考场节奏。",
+        "base_weeks": 3,
+        "intensity_hours": "每周 18-20 小时",
+        "skill_weights": {
+            "listening": 0.26,
+            "speaking": 0.24,
+            "reading": 0.22,
+            "writing": 0.28,
+        },
+        "skill_focus": {
+            "listening": [
+                "每周完成 2 套全真听力并进行错题复盘",
+                "利用跟读功能保持语速和语调的敏感度",
+                "重点攻克高频错词，结合词汇手册巩固",
+            ],
+            "speaking": [
+                "隔日进行一次完整的口语模考，强化考场感",
+                "复盘 AI 反馈中的弱项并即时修正",
+                "打磨个性化开场白与结束语，保持自信",
+            ],
+            "reading": [
+                "保持做题速度，复习题型策略",
+                "错题本每日回顾，防止旧错再犯",
+                "强化段落定位与关键词预测能力",
+            ],
+            "writing": [
+                "保持 Task1+Task2 全套练习的节奏",
+                "用 AI 批改确认最后的语言准确度",
+                "整理高分范文亮点，确保考试前形成记忆",
+            ],
+        },
+        "milestones": [
+            "完成 3 套全真模考并生成完整分数报告",
+            "四项能力雷达图趋于均衡，无明显短板",
+            "建立考试日前三天的维持方案（睡眠、复习、模拟）",
+        ],
+        "checkpoint": "模考成绩达到或高于目标分数，进入考前维护阶段",
+        "progress_metrics": {
+            "listening": "全真模考波动 ≤ 1.0 分",
+            "speaking": "AI 流利度 ≥ 7.0",
+            "reading": "错题率维持在 15% 以内",
+            "writing": "Task2 总分稳定在目标分数",
+        },
+    },
+}
+
+TARGET_RECOMMENDATIONS: Dict[str, Dict[str, object]] = {
+    "5.5": {
+        "score_profile": "建议将重点放在基础语音、语法与核心词汇积累上，逐步提升做题速度。",
+        "listening_focus": "坚持精听+跟读结合，利用自动转写确认基础听辨能力。",
+        "speaking_focus": "建立常见话题回答模板，确保语法准确率。",
+        "reading_focus": "优先掌握段落主旨题与信息匹配题的定位方法。",
+        "writing_focus": "Task1 描述准确，Task2 避免跑题，句型以清晰简洁为主。",
+        "mock_test_frequency": "每 3 周一次阶段性模考，关注时间管理。",
+        "ai_feedback_expectation": "重点跟踪发音准确度和语法纠错建议。",
+    },
+    "6.5": {
+        "score_profile": "需要在保持基础稳定的同时，提升词汇表达和论证深度。",
+        "listening_focus": "关注 Section 3&4 的细节信息与同义替换能力。",
+        "speaking_focus": "通过 AI 反馈提高词汇多样性与逻辑连贯。",
+        "reading_focus": "强化推断题与句子插入题的准确率。",
+        "writing_focus": "确保 Task2 结构完整，段内论证充分，有清晰的段首主题句。",
+        "mock_test_frequency": "每 2 周一次全真模考，记录波动区间。",
+        "ai_feedback_expectation": "同时关注语法、词汇和逻辑结构维度的改进。",
+    },
+    "7.5+": {
+        "score_profile": "需要高强度训练与细节打磨，目标是突破高级表达与稳定度。",
+        "listening_focus": "保持高频全真模考，精听高难度题型并追求接近满分。",
+        "speaking_focus": "强化论证深度与地道表达，练习考场随机应变能力。",
+        "reading_focus": "控制全篇耗时 55 分钟以内，保证复杂题型的准确率。",
+        "writing_focus": "Task2 目标达到 7.5+，关注语篇衔接、论证力度与词汇高级感。",
+        "mock_test_frequency": "每周一次全真模考并输出完整分析报告。",
+        "ai_feedback_expectation": "需要细化到句法复杂度、词汇多样性和论证逻辑的高阶反馈。",
+    },
+}
+
+DEFAULT_DAILY_TEMPLATE = {
+    "morning": [
+        "15 分钟发音热身 + 前一天错词复习",
+        "听力精听或阅读精读 45 分钟",
+    ],
+    "afternoon": [
+        "写作或口语主攻训练 60 分钟",
+        "题型专项练习 45 分钟",
+    ],
+    "evening": [
+        "当天错题与 AI 反馈复盘",
+        "安排次日学习任务并打卡进度",
+    ],
+}
+
+SKILL_LIBRARY: Dict[str, Dict[str, object]] = {
+    "listening": {
+        "title": "听力训练模块",
+        "core_features": [
+            "真题音频导入与逐句/逐段播放",
+            "听写对比与自动转写，识别错词",
+            "错词统计与个人生词本自动生成",
+            "跟读功能 + 发音准确度评分",
+        ],
+        "training_modes": [
+            "精听模式：逐句播放并配合自动转写比对",
+            "泛听模式：整段播放并生成摘要，考查全局理解",
+            "错词巩固：同步到词汇手册，进行间隔复习",
+        ],
+        "data_points": [
+            "精听准确率与错词类型分布",
+            "跟读打分趋势（发音/语调/连读）",
+            "真题完成时间与正确率",
+        ],
+    },
+    "speaking": {
+        "title": "口语练习模块",
+        "core_features": [
+            "雅思口语题库（Part1/Part2/Part3）",
+            "模拟考试模式：计时问答与自动录音",
+            "语音识别转写与实时字幕",
+            "AI 考官反馈（发音、流利度、语法、词汇）",
+        ],
+        "training_modes": [
+            "限时单题演练：1-2 分钟输出",
+            "全套模拟：按考场流程自动计时与录音",
+            "AI 回放：查看逐句字幕与纠错建议",
+        ],
+        "data_points": [
+            "发音准确度、语法错误密度、词汇多样性",
+            "Part2 结构完整度评分",
+            "回答时长与停顿分布",
+        ],
+    },
+    "reading": {
+        "title": "阅读理解模块",
+        "core_features": [
+            "精读/略读双模式切换",
+            "自动批改并标注定位句",
+            "单词高亮提示（即点即义）",
+            "错题本按题型与难度归类",
+        ],
+        "training_modes": [
+            "精读拆解：突出长难句结构与逻辑",
+            "略读冲刺：限定时间完成整篇文章",
+            "错题重做：根据题型再次演练并追踪准确率",
+        ],
+        "data_points": [
+            "不同题型正确率与平均耗时",
+            "关键生词与同义替换清单",
+            "阅读速度（词/分钟）趋势",
+        ],
+    },
+    "writing": {
+        "title": "写作练习模块",
+        "core_features": [
+            "Task1/Task2 作文输入与版本管理",
+            "AI 批改（结构、逻辑、语法、词汇）",
+            "高分范文对照与亮点提示",
+            "常用句式与模板推荐",
+        ],
+        "training_modes": [
+            "结构梳理：拆解段落主题与逻辑",
+            "限时模写：Task2 全流程 40 分钟训练",
+            "AI 精修：根据建议二次润色并追踪改动",
+        ],
+        "data_points": [
+            "段落逻辑得分与语法准确率",
+            "词汇丰富度与搭配错误",
+            "不同题型（对比、流程、观点）的表现",
+        ],
+    },
+}
+
+SUPPORTING_TOOLS = [
+    {
+        "id": "progress-tracker",
+        "name": "学习进度追踪",
+        "description": "提供学习日历、目标完成度可视化以及学习曲线趋势图。",
+        "capabilities": [
+            "可视化学习日历与累计时长",
+            "按技能展示达标进度与差距",
+            "生成阶段性总结和提醒",
+        ],
+    },
+    {
+        "id": "review-engine",
+        "name": "错题本与复习机制",
+        "description": "自动整理错题与高频错词，结合间隔复习算法推送复习任务。",
+        "capabilities": [
+            "题型/难度双维度分类",
+            "自动生成复习提醒与巩固练习",
+            "与词汇手册联动形成个性化材料",
+        ],
+    },
+    {
+        "id": "mock-exam-center",
+        "name": "模拟考试中心",
+        "description": "支持全真模考、计时与自动评分，生成分析报告。",
+        "capabilities": [
+            "听说读写全流程计时",
+            "自动整合 AI 批改与评分",
+            "输出雷达图与弱项分析",
+        ],
+    },
+    {
+        "id": "vocabulary-lab",
+        "name": "词汇手册",
+        "description": "整合个人错词与雅思高频词，提供发音、例句与间隔复习。",
+        "capabilities": [
+            "自动同步听力错词与阅读生词",
+            "TTS 发音与真题例句",
+            "灵活设定复习节奏与提醒",
+        ],
+    },
+    {
+        "id": "insight-reports",
+        "name": "学习报告与反馈",
+        "description": "生成四项能力雷达图、弱项分析与提升建议。",
+        "capabilities": [
+            "跨阶段对比，识别波动",
+            "针对弱项推送专项任务",
+            "提供下一阶段学习建议",
+        ],
+    },
+]
+
+MOCK_EXAMS = [
+    {
+        "id": "standard-full",
+        "title": "全真模拟套题",
+        "duration_minutes": 170,
+        "recommended_stage": ["core", "advanced", "sprint"],
+        "score_focus": "用于评估综合水平，生成详细分数报告。",
+        "report_contents": [
+            "四项能力得分与目标差距",
+            "时间管理分析",
+            "高频错误词汇与题型预警",
+        ],
+    },
+    {
+        "id": "speaking-intensive",
+        "title": "口语强化模考",
+        "duration_minutes": 15,
+        "recommended_stage": ["core", "advanced", "sprint"],
+        "score_focus": "突出发音、流利度与词汇多样性评分。",
+        "report_contents": [
+            "AI 考官逐句点评",
+            "语法与词汇建议",
+            "情景化改进建议",
+        ],
+    },
+    {
+        "id": "writing-dual",
+        "title": "写作双任务演练",
+        "duration_minutes": 90,
+        "recommended_stage": ["advanced", "sprint"],
+        "score_focus": "检验 Task1/Task2 时间掌控与结构合理性。",
+        "report_contents": [
+            "结构与逻辑评分",
+            "语法准确性与词汇密度",
+            "高分范文对照分析",
+        ],
+    },
+]
+
+VOCABULARY_DECKS: Dict[str, Dict[str, object]] = {
+    "foundation": {
+        "level": "A2-B1",
+        "focus": "核心场景词汇与生活化表达",
+        "spacing_strategy": "2-2-3-5 天间隔复习",
+        "bundle_size": 20,
+        "activities": [
+            "跟读 + TTS 发音记忆",
+            "语境例句理解",
+            "拼写听写双模式巩固",
+        ],
+    },
+    "core": {
+        "level": "B1-B2",
+        "focus": "题型高频词与搭配",
+        "spacing_strategy": "1-2-4-6 天间隔复习",
+        "bundle_size": 25,
+        "activities": [
+            "词根词缀拆解",
+            "阅读同义替换练习",
+            "结合写作模板造句",
+        ],
+    },
+    "advanced": {
+        "level": "B2-C1",
+        "focus": "学术词汇与表达升级",
+        "spacing_strategy": "1-3-5-7 天间隔复习",
+        "bundle_size": 25,
+        "activities": [
+            "主题词汇扩展",
+            "口语即兴应用",
+            "写作多样化替换训练",
+        ],
+    },
+    "sprint": {
+        "level": "C1",
+        "focus": "高分搭配与考前必背",
+        "spacing_strategy": "1-2-3-4 天短周期巩固",
+        "bundle_size": 30,
+        "activities": [
+            "口语模考实时调用",
+            "写作段落速记",
+            "听力错词最后冲刺",
+        ],
+    },
+}
+
+AI_INTEGRATIONS = {
+    "asr": {
+        "purpose": "口语录音自动转写、发音分析与听写对比",
+        "service_boundary": "通过独立 ASR 服务接口接入，支持后续替换供应商",
+        "data_output": ["逐句文本", "发音评分", "停顿/语速分析"],
+    },
+    "tts": {
+        "purpose": "词汇与范文朗读、听力精听辅助",
+        "service_boundary": "TTS 服务独立部署，通过统一音频缓存层供前端调用",
+        "data_output": ["多语速音频", "语音标注"],
+    },
+    "llm": {
+        "purpose": "写作批改、口语反馈与个性化学习建议",
+        "service_boundary": "统一的 LLM Gateway 负责路由至不同大模型",
+        "data_output": ["结构点评", "语言建议", "定制任务列表"],
+    },
+    "analytics": {
+        "purpose": "学习行为统计与报告生成",
+        "service_boundary": "事件流进入数据仓库，支持进度备份与恢复",
+        "data_output": ["学习曲线", "词汇掌握度", "模考波动"]
+    },
+}
+
+
+class SkillScores(BaseModel):
+    """User skill scores in IELTS scale."""
+
+    listening: float = Field(..., ge=0.0, le=9.0)
+    speaking: float = Field(..., ge=0.0, le=9.0)
+    reading: float = Field(..., ge=0.0, le=9.0)
+    writing: float = Field(..., ge=0.0, le=9.0)
+
+
+class AssessmentRequest(BaseModel):
+    current_scores: SkillScores
+    target_band: Literal["5.5", "6.5", "7.5+"]
+    weekly_study_hours: conint(ge=5, le=60) = Field(
+        ..., description="Available study hours per week"
+    )
+    weeks_until_exam: conint(ge=1, le=52)
+    preferred_focus: Optional[List[SkillName]] = Field(
+        None, description="Optional skills that the learner wants to emphasise"
+    )
+
+
+class ProgressReviewRequest(BaseModel):
+    baseline_scores: SkillScores
+    latest_scores: SkillScores
+    weeks_elapsed: conint(ge=1, le=52)
+    total_logged_hours: conint(ge=1, le=800)
+    completed_mock_tests: Optional[conint(ge=0, le=40)] = 0
+
+
+def _average_score(scores: SkillScores) -> float:
+    values = scores.dict().values()
+    return round(sum(values) / len(values), 2)
+
+
+def _min_score(scores: SkillScores) -> float:
+    return min(scores.dict().values())
+
+
+def _phase_sequence(scores: SkillScores, target_score: float) -> List[str]:
+    avg = _average_score(scores)
+    min_score = _min_score(scores)
+    gap = max(target_score - avg, 0)
+    phases: List[str] = []
+
+    if gap > 1.4 or min_score < 4.5:
+        phases.append("foundation")
+    if gap > 1.0 or min_score < 5.5:
+        phases.append("core")
+    if gap > 0.6 or min_score < 6.0:
+        phases.append("advanced")
+    phases.append("sprint")
+
+    ordered = []
+    for stage in ["foundation", "core", "advanced", "sprint"]:
+        if stage in phases and stage not in ordered:
+            ordered.append(stage)
+    return ordered
+
+
+def _allocate_weeks(phases: List[str], total_weeks: int) -> Dict[str, int]:
+    if not phases:
+        return {}
+    if total_weeks < len(phases):
+        phases = phases[-total_weeks:]
+
+    base_total = sum(int(STAGE_LIBRARY[p]["base_weeks"]) for p in phases)
+    allocations = [
+        [
+            stage,
+            max(
+                1,
+                int(round(total_weeks * (STAGE_LIBRARY[stage]["base_weeks"] / base_total))),
+            ),
+        ]
+        for stage in phases
+    ]
+    diff = total_weeks - sum(value for _, value in allocations)
+    idx = 0
+    while diff != 0 and allocations:
+        stage, weeks = allocations[idx % len(allocations)]
+        if diff > 0:
+            allocations[idx % len(allocations)][1] = weeks + 1
+            diff -= 1
+        elif weeks > 1:
+            allocations[idx % len(allocations)][1] = weeks - 1
+            diff += 1
+        idx += 1
+    return {stage: weeks for stage, weeks in allocations}
+
+
+def _build_weekly_schedule(stage: str, weekly_hours: int) -> List[Dict[str, object]]:
+    stage_info = STAGE_LIBRARY[stage]
+    weights = stage_info["skill_weights"]
+    allocation = []
+    total_hours = 0.0
+    for skill, weight in weights.items():
+        hours = round(weekly_hours * weight, 1)
+        total_hours += hours
+        allocation.append({
+            "skill": skill,
+            "hours": hours,
+            "focus": stage_info["skill_focus"][skill],
+        })
+    # Adjust rounding drift so the sum equals weekly_hours approximately.
+    if allocation:
+        drift = round(weekly_hours - total_hours, 1)
+        if abs(drift) >= 0.1:
+            allocation[0]["hours"] = round(allocation[0]["hours"] + drift, 1)
+    return allocation
+
+
+def _render_phase_payload(stage: str, weeks: int, weekly_hours: int) -> Dict[str, object]:
+    stage_info = STAGE_LIBRARY[stage]
+    weekly_schedule = _build_weekly_schedule(stage, weekly_hours)
+    return {
+        "stage": stage,
+        "label": stage_info["label"],
+        "duration_weeks": weeks,
+        "intensity": stage_info["intensity_hours"],
+        "summary": stage_info["summary"],
+        "milestones": stage_info["milestones"],
+        "checkpoint": stage_info["checkpoint"],
+        "progress_metrics": stage_info["progress_metrics"],
+        "weekly_schedule": weekly_schedule,
+    }
+
+
+def _detect_priority_skills(scores: SkillScores, preferred: Optional[List[SkillName]]) -> List[SkillName]:
+    values = scores.dict()
+    sorted_skills = sorted(values.items(), key=lambda item: item[1])
+    priority = [skill for skill, _ in sorted_skills[:2]]
+    if preferred:
+        for skill in preferred:
+            if skill not in priority:
+                priority.append(skill)
+    return priority[:4]
+
+
+def _calculate_improvement(baseline: SkillScores, latest: SkillScores) -> Dict[str, float]:
+    return {
+        skill: round(latest.dict()[skill] - baseline.dict()[skill], 2)
+        for skill in baseline.dict().keys()
+    }
+
+
+def _weakest_skill(scores: SkillScores) -> SkillName:
+    values = scores.dict()
+    return min(values, key=values.get)  # type: ignore[return-value]
+
+
+@router.get("/modules")
+def get_skill_modules() -> Dict[str, Dict[str, object]]:
+    """Return descriptions of the four IELTS skill modules."""
+
+    return SKILL_LIBRARY
+
+
+@router.get("/supporting-tools")
+def get_supporting_tools() -> Dict[str, object]:
+    return {"tools": SUPPORTING_TOOLS}
+
+
+@router.get("/mock-tests")
+def get_mock_tests() -> Dict[str, object]:
+    return {"mock_tests": MOCK_EXAMS}
+
+
+@router.get("/vocabulary")
+def get_vocabulary_deck(stage: Literal["foundation", "core", "advanced", "sprint"] = Query("core")) -> Dict[str, object]:
+    deck = VOCABULARY_DECKS.get(stage)
+    if not deck:
+        raise HTTPException(status_code=404, detail="Vocabulary deck not found")
+    return {"stage": stage, "deck": deck}
+
+
+@router.get("/system-overview")
+def get_system_overview() -> Dict[str, object]:
+    return {
+        "modules": SKILL_LIBRARY,
+        "supporting_tools": SUPPORTING_TOOLS,
+        "integrations": AI_INTEGRATIONS,
+        "data_safeguards": {
+            "storage": [
+                "题库与素材库独立管理，支持定期更新",
+                "用户作答、音频与作文档案按租户隔离存储",
+            ],
+            "privacy": [
+                "音频与文本数据加密存储，可按需删除",
+                "进度数据支持导出、备份与恢复",
+            ],
+        },
+    }
+
+
+@router.post("/assessment")
+def create_learning_plan(payload: AssessmentRequest) -> Dict[str, object]:
+    target_score = TARGET_BANDS[payload.target_band]
+    current_avg = _average_score(payload.current_scores)
+    weakest_skill = _weakest_skill(payload.current_scores)
+    phases = _phase_sequence(payload.current_scores, target_score)
+    if not phases:
+        raise HTTPException(status_code=400, detail="无法生成学习阶段，请检查输入分数")
+
+    weeks_allocation = _allocate_weeks(phases, payload.weeks_until_exam)
+    plan = [
+        _render_phase_payload(stage, weeks_allocation.get(stage, 0), payload.weekly_study_hours)
+        for stage in phases
+        if weeks_allocation.get(stage)
+    ]
+    priority_skills = _detect_priority_skills(payload.current_scores, payload.preferred_focus)
+
+    return {
+        "target_band": payload.target_band,
+        "target_score_numeric": target_score,
+        "current_average": current_avg,
+        "overall_gap": round(target_score - current_avg, 2),
+        "phase_plan": plan,
+        "priority_skills": priority_skills,
+        "recommendations": TARGET_RECOMMENDATIONS[payload.target_band],
+        "daily_template": DEFAULT_DAILY_TEMPLATE,
+        "ai_integrations": AI_INTEGRATIONS,
+        "weakest_skill": weakest_skill,
+    }
+
+
+@router.post("/progress/review")
+def review_progress(payload: ProgressReviewRequest) -> Dict[str, object]:
+    improvements = _calculate_improvement(payload.baseline_scores, payload.latest_scores)
+    weakest = _weakest_skill(payload.latest_scores)
+    avg_latest = _average_score(payload.latest_scores)
+
+    suggested_stage = "sprint"
+    for stage in ["foundation", "core", "advanced"]:
+        if avg_latest < TARGET_BANDS["6.5"] and stage == "foundation":
+            suggested_stage = stage
+            break
+        if avg_latest < TARGET_BANDS["7.5+"] and stage == "core":
+            suggested_stage = stage
+            break
+    priority = sorted(improvements.items(), key=lambda item: item[1])[:2]
+    focus_skills = [skill for skill, _ in priority]
+
+    return {
+        "weeks_elapsed": payload.weeks_elapsed,
+        "total_logged_hours": payload.total_logged_hours,
+        "score_improvements": improvements,
+        "weakest_skill": weakest,
+        "suggested_next_stage": suggested_stage,
+        "focus_recommendations": focus_skills,
+        "next_actions": [
+            "根据错题本安排阶段性复盘，锁定弱项技能",
+            "安排下一次模考并关联 AI 反馈报告",
+            "更新词汇手册的复习节奏，保持记忆曲线",
+        ],
+        "mock_test_suggestion": {
+            "completed": payload.completed_mock_tests,
+            "next": "建议 7 天内安排一次全真模考" if payload.completed_mock_tests < 3 else "保持每周一次模考频率",
+        },
+    }

--- a/backend/main.py
+++ b/backend/main.py
@@ -9,6 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 # --- 静态导入所有功能模块的路由 ---
 from features.core_api.router import router as core_api_router
 from features.chess_academy.router import router as chess_academy_router
+from features.ielts_study_system.router import router as ielts_study_router
 # ==============================================================================
 # [示例] 如何添加新的功能模块
 # ------------------------------------------------------------------------------
@@ -54,6 +55,8 @@ app.include_router(core_api_router, prefix="/api")
 print("✅ Successfully loaded feature: core_api")
 app.include_router(chess_academy_router, prefix="/api")
 print("✅ Successfully loaded feature: chess_academy")
+app.include_router(ielts_study_router, prefix="/api")
+print("✅ Successfully loaded feature: ielts_study_system")
 
 # ==============================================================================
 # [示例] 如何注册新的功能模块路由

--- a/frontend/config.js
+++ b/frontend/config.js
@@ -65,4 +65,10 @@ const FEATURES = [
         description: '面向小学生的国际象棋学习和对弈模块，包含智能棋友、友好提示与每日谜题。',
         isFullPath: true
     },
+    {
+        path: 'ielts-study-system/index.html',
+        name: '🎓 雅思智能学习系统',
+        description: '专业雅思备考平台，整合听说读写训练、个性化学习路径、词汇复习与模考分析。',
+        isFullPath: true
+    },
 ];

--- a/frontend/features/ielts-study-system/index.html
+++ b/frontend/features/ielts-study-system/index.html
@@ -1,0 +1,405 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>雅思学习系统 - flashmvp</title>
+    <link rel="stylesheet" href="../../style.css">
+    <link rel="icon" href="../../public/favicon.ico">
+</head>
+<body>
+    <div class="feature-container ielts-container">
+        <header>
+            <div>
+                <h1>雅思(IELTS)智能学习系统</h1>
+                <p class="intro">面向学生与职场考生的全栈备考方案，覆盖听、说、读、写四项技能，支持个性化学习路径与数据化进度追踪。</p>
+            </div>
+            <a class="back-link" href="../../dashboard.html">← 返回功能中心</a>
+        </header>
+
+        <main>
+            <section class="panel">
+                <h2>01. 个性化学习路径规划</h2>
+                <p>输入当前分数与备考时间，系统会结合目标分数生成阶段性学习路径、重点技能与每日节奏建议。</p>
+                <form id="assessmentForm" class="form-grid">
+                    <div class="form-group">
+                        <label for="targetBand">目标分数</label>
+                        <select id="targetBand" required>
+                            <option value="5.5">5.5</option>
+                            <option value="6.5" selected>6.5</option>
+                            <option value="7.5+">7.5+</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label for="listeningScore">听力现水平</label>
+                        <input type="number" id="listeningScore" step="0.5" min="0" max="9" value="5.0" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="speakingScore">口语现水平</label>
+                        <input type="number" id="speakingScore" step="0.5" min="0" max="9" value="5.0" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="readingScore">阅读现水平</label>
+                        <input type="number" id="readingScore" step="0.5" min="0" max="9" value="5.5" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="writingScore">写作现水平</label>
+                        <input type="number" id="writingScore" step="0.5" min="0" max="9" value="5.0" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="weeklyHours">每周可投入时长</label>
+                        <input type="number" id="weeklyHours" min="5" max="60" value="15" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="weeksUntilExam">距离考试(周)</label>
+                        <input type="number" id="weeksUntilExam" min="1" max="52" value="12" required>
+                    </div>
+                    <div class="form-group form-group-full">
+                        <span>偏好强化技能（可多选）</span>
+                        <div class="checkbox-row">
+                            <label><input type="checkbox" value="listening"> 听力</label>
+                            <label><input type="checkbox" value="speaking"> 口语</label>
+                            <label><input type="checkbox" value="reading"> 阅读</label>
+                            <label><input type="checkbox" value="writing"> 写作</label>
+                        </div>
+                    </div>
+                    <div class="form-actions form-group-full">
+                        <button type="submit" id="planBtn">生成学习计划</button>
+                    </div>
+                </form>
+                <div id="planOutput" class="result-box" style="display:none;"></div>
+            </section>
+
+            <section class="panel">
+                <h2>02. 听说读写模块全景</h2>
+                <p>系统化规划四大模块的训练路径，可根据阶段自由组合，确保强项保持、弱项补齐。</p>
+                <div id="moduleGrid" class="module-grid"></div>
+            </section>
+
+            <section class="panel">
+                <h2>03. 支撑与激励系统</h2>
+                <p>学习进度追踪、错题复习、词汇手册与报告分析模块协同工作，帮助你持续保持动力。</p>
+                <div id="supportingTools" class="supporting-grid"></div>
+            </section>
+
+            <section class="panel">
+                <h2>04. 模拟考试 & 词汇手册</h2>
+                <div class="dual-column">
+                    <div>
+                        <h3>模拟考试中心</h3>
+                        <p>选择适合阶段的模考套题，自动生成评分与弱项分析。</p>
+                        <div id="mockTests" class="mock-list"></div>
+                    </div>
+                    <div>
+                        <h3>词汇手册</h3>
+                        <label for="vocabStage">当前训练阶段</label>
+                        <select id="vocabStage">
+                            <option value="foundation">入门衔接</option>
+                            <option value="core" selected>基础夯实</option>
+                            <option value="advanced">进阶突破</option>
+                            <option value="sprint">冲刺拔高</option>
+                        </select>
+                        <div id="vocabDeck" class="vocab-box"></div>
+                    </div>
+                </div>
+            </section>
+
+            <section class="panel">
+                <h2>05. 阶段复盘助手</h2>
+                <p>对比阶段前后的分数变化，智能推荐下一阶段重点与模考节奏。</p>
+                <form id="progressForm" class="form-grid">
+                    <div class="form-group">
+                        <label for="baselineListening">初始听力</label>
+                        <input type="number" id="baselineListening" step="0.5" min="0" max="9" value="5.0" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="baselineSpeaking">初始口语</label>
+                        <input type="number" id="baselineSpeaking" step="0.5" min="0" max="9" value="5.0" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="baselineReading">初始阅读</label>
+                        <input type="number" id="baselineReading" step="0.5" min="0" max="9" value="5.5" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="baselineWriting">初始写作</label>
+                        <input type="number" id="baselineWriting" step="0.5" min="0" max="9" value="5.0" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="latestListening">最新听力</label>
+                        <input type="number" id="latestListening" step="0.5" min="0" max="9" value="6.0" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="latestSpeaking">最新口语</label>
+                        <input type="number" id="latestSpeaking" step="0.5" min="0" max="9" value="5.5" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="latestReading">最新阅读</label>
+                        <input type="number" id="latestReading" step="0.5" min="0" max="9" value="6.0" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="latestWriting">最新写作</label>
+                        <input type="number" id="latestWriting" step="0.5" min="0" max="9" value="5.5" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="weeksElapsed">已学习周数</label>
+                        <input type="number" id="weeksElapsed" min="1" max="52" value="6" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="loggedHours">累计学习时长</label>
+                        <input type="number" id="loggedHours" min="1" max="800" value="120" required>
+                    </div>
+                    <div class="form-group">
+                        <label for="mockCompleted">已完成模考次数</label>
+                        <input type="number" id="mockCompleted" min="0" max="40" value="2" required>
+                    </div>
+                    <div class="form-actions form-group-full">
+                        <button type="submit" id="reviewBtn">生成复盘建议</button>
+                    </div>
+                </form>
+                <div id="progressOutput" class="result-box" style="display:none;"></div>
+            </section>
+
+            <section class="panel">
+                <h2>06. 架构与扩展</h2>
+                <p>语音识别、语音合成与大语言模型服务均通过标准接口接入，可随时替换供应商；平台支持数据隔离与备份恢复。</p>
+                <div id="systemOverview" class="system-overview"></div>
+            </section>
+        </main>
+    </div>
+
+    <script src="../../config.js"></script>
+    <script src="../../auth.js"></script>
+    <script src="../../models.js"></script>
+    <script src="../../usage.js"></script>
+    <script src="./script.js"></script>
+    <style>
+        .ielts-container header {
+            align-items: flex-start;
+            gap: 24px;
+        }
+        .ielts-container .intro {
+            max-width: 640px;
+            color: #4a4a4a;
+        }
+        .back-link {
+            align-self: center;
+            color: #007bff;
+            text-decoration: none;
+            font-weight: 500;
+        }
+        .panel + .panel {
+            margin-top: 30px;
+        }
+        .form-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 16px 20px;
+            margin-top: 20px;
+        }
+        .form-group {
+            display: flex;
+            flex-direction: column;
+            gap: 6px;
+        }
+        .form-group-full {
+            grid-column: 1 / -1;
+        }
+        .checkbox-row {
+            display: flex;
+            gap: 18px;
+            flex-wrap: wrap;
+        }
+        .form-actions {
+            display: flex;
+            justify-content: flex-end;
+        }
+        .chip {
+            display: inline-block;
+            background: #e8f3ff;
+            color: #0b61c3;
+            padding: 4px 10px;
+            border-radius: 999px;
+            font-size: 13px;
+            margin-right: 6px;
+        }
+        .plan-meta {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+            gap: 12px;
+            margin-bottom: 24px;
+        }
+        .plan-meta div {
+            background: #f5f8ff;
+            padding: 12px 16px;
+            border-radius: 8px;
+        }
+        .meta-title {
+            display: block;
+            font-size: 13px;
+            color: #667085;
+            margin-bottom: 4px;
+        }
+        .phase-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+            gap: 18px;
+        }
+        .phase-card {
+            border: 1px solid #e3e8f0;
+            border-radius: 10px;
+            padding: 16px;
+            display: flex;
+            flex-direction: column;
+            gap: 16px;
+            background: #fff;
+        }
+        .phase-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            font-size: 14px;
+            color: #475467;
+        }
+        .phase-summary {
+            color: #4b5563;
+            font-size: 14px;
+        }
+        .phase-section h4 {
+            font-size: 14px;
+            margin-bottom: 6px;
+            color: #1f2937;
+        }
+        .phase-section ul {
+            padding-left: 18px;
+            color: #4a5568;
+            font-size: 14px;
+        }
+        .plan-section + .plan-section {
+            margin-top: 24px;
+        }
+        .daily-template {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 14px;
+        }
+        .daily-block {
+            background: #f8fafc;
+            border-radius: 8px;
+            padding: 12px 14px;
+        }
+        .daily-block h4 {
+            font-size: 13px;
+            color: #0f172a;
+            margin-bottom: 6px;
+        }
+        .daily-block ul {
+            padding-left: 18px;
+            font-size: 13px;
+            color: #475467;
+        }
+        .module-grid,
+        .supporting-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+            gap: 18px;
+            margin-top: 18px;
+        }
+        .module-card,
+        .support-card {
+            border: 1px solid #e5e7eb;
+            border-radius: 10px;
+            padding: 18px;
+            background: #fff;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+        .module-card h3,
+        .support-card h3 {
+            color: #1f2937;
+        }
+        .module-section h4,
+        .support-card ul {
+            font-size: 14px;
+        }
+        .dual-column {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+            gap: 24px;
+            margin-top: 16px;
+        }
+        .mock-list {
+            display: grid;
+            gap: 16px;
+        }
+        .mock-card {
+            border: 1px solid #dbe3f0;
+            border-radius: 10px;
+            padding: 16px;
+            background: #fff;
+        }
+        .mock-header {
+            display: flex;
+            justify-content: space-between;
+            margin-bottom: 8px;
+            color: #344054;
+        }
+        .vocab-box {
+            margin-top: 12px;
+            border: 1px solid #e5e7eb;
+            border-radius: 10px;
+            padding: 16px;
+            background: #fff;
+        }
+        .vocab-meta {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+            gap: 12px;
+            margin-bottom: 12px;
+        }
+        .integration-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+            gap: 16px;
+        }
+        .integration-card {
+            border: 1px solid #d9e2ef;
+            border-radius: 10px;
+            padding: 16px;
+            background: #fff;
+        }
+        .integration-card h4 {
+            margin-bottom: 6px;
+        }
+        .integration-boundary {
+            font-size: 13px;
+            color: #4a4a4a;
+        }
+        .security-block {
+            margin-top: 20px;
+            border-radius: 10px;
+            border: 1px solid #e2e8f0;
+            padding: 16px;
+            background: #f8fafc;
+        }
+        .security-columns {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 16px;
+            margin-top: 12px;
+        }
+        .error {
+            color: #c53030;
+        }
+        @media (max-width: 720px) {
+            .ielts-container header {
+                flex-direction: column;
+                align-items: flex-start;
+            }
+            .form-actions {
+                justify-content: flex-start;
+            }
+        }
+    </style>
+</body>
+</html>

--- a/frontend/features/ielts-study-system/script.js
+++ b/frontend/features/ielts-study-system/script.js
@@ -1,0 +1,460 @@
+// frontend/features/ielts-study-system/script.js
+// 雅思学习系统前端交互逻辑
+
+checkAuth();
+
+const skillLabels = {
+    listening: '听力',
+    speaking: '口语',
+    reading: '阅读',
+    writing: '写作',
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+    initialisePage();
+});
+
+async function initialisePage() {
+    attachEventHandlers();
+    await Promise.all([
+        loadSkillModules(),
+        loadSupportingTools(),
+        loadMockTests(),
+        loadVocabularyDeck(),
+        loadSystemOverview(),
+    ]);
+}
+
+function attachEventHandlers() {
+    document.getElementById('assessmentForm').addEventListener('submit', handlePlanSubmit);
+    document.getElementById('progressForm').addEventListener('submit', handleProgressSubmit);
+    document.getElementById('vocabStage').addEventListener('change', loadVocabularyDeck);
+}
+
+async function handlePlanSubmit(event) {
+    event.preventDefault();
+    const planBtn = document.getElementById('planBtn');
+    const planOutput = document.getElementById('planOutput');
+
+    const payload = buildAssessmentPayload();
+
+    planBtn.disabled = true;
+    planBtn.textContent = '生成中...';
+    planOutput.style.display = 'block';
+    planOutput.innerHTML = '正在生成个性化学习路径，请稍候...';
+
+    try {
+        if (window.usageTracker) {
+            usageTracker.track({ feature: 'ielts-study-system', action: 'plan-request' });
+        }
+
+        const response = await fetch('/api/ielts/assessment', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+            const message = await response.text();
+            throw new Error(message || '生成学习计划失败');
+        }
+
+        const data = await response.json();
+        renderPlan(data);
+
+        if (window.usageTracker) {
+            usageTracker.track({ feature: 'ielts-study-system', action: 'plan-success' });
+        }
+    } catch (error) {
+        console.error(error);
+        planOutput.innerHTML = `<span class="error">生成失败：${error.message}</span>`;
+    } finally {
+        planBtn.disabled = false;
+        planBtn.textContent = '生成学习计划';
+    }
+}
+
+function buildAssessmentPayload() {
+    const targetBand = document.getElementById('targetBand').value;
+    const weeklyHours = Number(document.getElementById('weeklyHours').value);
+    const weeksUntilExam = Number(document.getElementById('weeksUntilExam').value);
+
+    const currentScores = {
+        listening: Number(document.getElementById('listeningScore').value),
+        speaking: Number(document.getElementById('speakingScore').value),
+        reading: Number(document.getElementById('readingScore').value),
+        writing: Number(document.getElementById('writingScore').value),
+    };
+
+    const preferred = Array.from(document.querySelectorAll('.checkbox-row input:checked')).map((el) => el.value);
+
+    const payload = {
+        target_band: targetBand,
+        weekly_study_hours: weeklyHours,
+        weeks_until_exam: weeksUntilExam,
+        current_scores: currentScores,
+    };
+
+    if (preferred.length > 0) {
+        payload.preferred_focus = preferred;
+    }
+
+    return payload;
+}
+
+function renderPlan(plan) {
+    const container = document.getElementById('planOutput');
+    container.style.display = 'block';
+
+    const priorityChips = plan.priority_skills
+        .map((skill) => `<span class="chip">${skillLabels[skill] || skill}</span>`)
+        .join('');
+
+    const phasesHtml = plan.phase_plan
+        .map((phase) => `
+            <div class="phase-card">
+                <div class="phase-header">
+                    <strong>${phase.label}</strong>
+                    <span>${phase.duration_weeks} 周｜${phase.intensity}</span>
+                </div>
+                <p class="phase-summary">${phase.summary}</p>
+                <div class="phase-section">
+                    <h4>阶段里程碑</h4>
+                    <ul>${phase.milestones.map((item) => `<li>${item}</li>`).join('')}</ul>
+                </div>
+                <div class="phase-section">
+                    <h4>周学习结构</h4>
+                    ${renderWeeklySchedule(phase.weekly_schedule)}
+                </div>
+                <div class="phase-section">
+                    <h4>达标指标</h4>
+                    <ul>
+                        ${Object.entries(phase.progress_metrics)
+                            .map(([skill, text]) => `<li><strong>${skillLabels[skill] || skill}</strong>：${text}</li>`)
+                            .join('')}
+                    </ul>
+                </div>
+                <div class="phase-section">
+                    <h4>阶段转入条件</h4>
+                    <p>${phase.checkpoint}</p>
+                </div>
+            </div>
+        `)
+        .join('');
+
+    const dailyTemplateHtml = Object.entries(plan.daily_template)
+        .map(
+            ([period, tasks]) => `
+            <div class="daily-block">
+                <h4>${period.toUpperCase()}</h4>
+                <ul>${tasks.map((task) => `<li>${task}</li>`).join('')}</ul>
+            </div>
+        `,
+        )
+        .join('');
+
+    container.innerHTML = `
+        <div class="plan-meta">
+            <div>
+                <span class="meta-title">目标分数</span>
+                <strong>${plan.target_band}</strong>
+            </div>
+            <div>
+                <span class="meta-title">当前均分</span>
+                <strong>${plan.current_average}</strong>
+            </div>
+            <div>
+                <span class="meta-title">分差</span>
+                <strong>${plan.overall_gap.toFixed(2)}</strong>
+            </div>
+            <div>
+                <span class="meta-title">弱项优先</span>
+                <div class="chip-group">${priorityChips}</div>
+            </div>
+        </div>
+        <div class="plan-section">
+            <h3>阶段化学习路径</h3>
+            <div class="phase-grid">${phasesHtml}</div>
+        </div>
+        <div class="plan-section">
+            <h3>每日节奏示例</h3>
+            <div class="daily-template">${dailyTemplateHtml}</div>
+        </div>
+        <div class="plan-section">
+            <h3>官方建议</h3>
+            ${renderRecommendation(plan.recommendations)}
+        </div>
+    `;
+}
+
+function renderWeeklySchedule(schedule) {
+    return `
+        <ul class="schedule-list">
+            ${schedule
+                .map(
+                    (item) => `
+                        <li>
+                            <div class="schedule-title">${skillLabels[item.skill] || item.skill}｜${item.hours} 小时</div>
+                            <ul>${item.focus.map((focus) => `<li>${focus}</li>`).join('')}</ul>
+                        </li>
+                    `,
+                )
+                .join('')}
+        </ul>
+    `;
+}
+
+function renderRecommendation(recommendation) {
+    return `
+        <ul class="recommendation-list">
+            <li><strong>分数策略：</strong>${recommendation.score_profile}</li>
+            <li><strong>听力重点：</strong>${recommendation.listening_focus}</li>
+            <li><strong>口语重点：</strong>${recommendation.speaking_focus}</li>
+            <li><strong>阅读重点：</strong>${recommendation.reading_focus}</li>
+            <li><strong>写作重点：</strong>${recommendation.writing_focus}</li>
+            <li><strong>模考节奏：</strong>${recommendation.mock_test_frequency}</li>
+            <li><strong>AI 反馈关注：</strong>${recommendation.ai_feedback_expectation}</li>
+        </ul>
+    `;
+}
+
+async function loadSkillModules() {
+    try {
+        const response = await fetch('/api/ielts/modules');
+        if (!response.ok) throw new Error('无法获取模块信息');
+        const data = await response.json();
+        const grid = document.getElementById('moduleGrid');
+        grid.innerHTML = Object.values(data)
+            .map((module) => `
+                <div class="module-card">
+                    <h3>${module.title}</h3>
+                    <div class="module-section">
+                        <h4>核心能力</h4>
+                        <ul>${module.core_features.map((item) => `<li>${item}</li>`).join('')}</ul>
+                    </div>
+                    <div class="module-section">
+                        <h4>训练模式</h4>
+                        <ul>${module.training_modes.map((item) => `<li>${item}</li>`).join('')}</ul>
+                    </div>
+                    <div class="module-section">
+                        <h4>数据追踪</h4>
+                        <ul>${module.data_points.map((item) => `<li>${item}</li>`).join('')}</ul>
+                    </div>
+                </div>
+            `)
+            .join('');
+    } catch (error) {
+        console.error(error);
+        document.getElementById('moduleGrid').innerHTML = '<p class="error">模块信息加载失败</p>';
+    }
+}
+
+async function loadSupportingTools() {
+    try {
+        const response = await fetch('/api/ielts/supporting-tools');
+        if (!response.ok) throw new Error('无法获取支撑工具信息');
+        const data = await response.json();
+        const container = document.getElementById('supportingTools');
+        container.innerHTML = data.tools
+            .map((tool) => `
+                <div class="support-card">
+                    <h3>${tool.name}</h3>
+                    <p>${tool.description}</p>
+                    <ul>${tool.capabilities.map((cap) => `<li>${cap}</li>`).join('')}</ul>
+                </div>
+            `)
+            .join('');
+    } catch (error) {
+        console.error(error);
+        document.getElementById('supportingTools').innerHTML = '<p class="error">支撑系统加载失败</p>';
+    }
+}
+
+async function loadMockTests() {
+    try {
+        const response = await fetch('/api/ielts/mock-tests');
+        if (!response.ok) throw new Error('无法获取模考信息');
+        const data = await response.json();
+        const container = document.getElementById('mockTests');
+        container.innerHTML = data.mock_tests
+            .map((test) => `
+                <div class="mock-card">
+                    <div class="mock-header">
+                        <strong>${test.title}</strong>
+                        <span>${test.duration_minutes} 分钟</span>
+                    </div>
+                    <p>${test.score_focus}</p>
+                    <h4>适用阶段</h4>
+                    <p>${test.recommended_stage.map((stage) => stage.toUpperCase()).join(' / ')}</p>
+                    <h4>报告内容</h4>
+                    <ul>${test.report_contents.map((item) => `<li>${item}</li>`).join('')}</ul>
+                </div>
+            `)
+            .join('');
+    } catch (error) {
+        console.error(error);
+        document.getElementById('mockTests').innerHTML = '<p class="error">模考信息加载失败</p>';
+    }
+}
+
+async function loadVocabularyDeck() {
+    const stage = document.getElementById('vocabStage').value;
+    try {
+        const response = await fetch(`/api/ielts/vocabulary?stage=${stage}`);
+        if (!response.ok) throw new Error('无法获取词汇手册');
+        const data = await response.json();
+        const deck = data.deck;
+        document.getElementById('vocabDeck').innerHTML = `
+            <div class="vocab-meta">
+                <div><span class="meta-title">词汇等级</span><strong>${deck.level}</strong></div>
+                <div><span class="meta-title">复习策略</span><strong>${deck.spacing_strategy}</strong></div>
+                <div><span class="meta-title">每日词量</span><strong>${deck.bundle_size} 词</strong></div>
+            </div>
+            <h4>推荐活动</h4>
+            <ul>${deck.activities.map((item) => `<li>${item}</li>`).join('')}</ul>
+        `;
+    } catch (error) {
+        console.error(error);
+        document.getElementById('vocabDeck').innerHTML = '<p class="error">词汇手册加载失败</p>';
+    }
+}
+
+async function loadSystemOverview() {
+    try {
+        const response = await fetch('/api/ielts/system-overview');
+        if (!response.ok) throw new Error('无法获取系统信息');
+        const data = await response.json();
+        renderSystemOverview(data);
+    } catch (error) {
+        console.error(error);
+        document.getElementById('systemOverview').innerHTML = '<p class="error">系统信息加载失败</p>';
+    }
+}
+
+function renderSystemOverview(data) {
+    const integrations = Object.entries(data.integrations)
+        .map(
+            ([key, item]) => `
+            <div class="integration-card">
+                <h4>${key.toUpperCase()}</h4>
+                <p>${item.purpose}</p>
+                <p class="integration-boundary">接入边界：${item.service_boundary}</p>
+                <ul>${item.data_output.map((out) => `<li>${out}</li>`).join('')}</ul>
+            </div>
+        `,
+        )
+        .join('');
+
+    document.getElementById('systemOverview').innerHTML = `
+        <div class="integration-grid">${integrations}</div>
+        <div class="security-block">
+            <h4>数据安全 & 隐私</h4>
+            <div class="security-columns">
+                <div>
+                    <h5>存储策略</h5>
+                    <ul>${data.data_safeguards.storage.map((item) => `<li>${item}</li>`).join('')}</ul>
+                </div>
+                <div>
+                    <h5>隐私保护</h5>
+                    <ul>${data.data_safeguards.privacy.map((item) => `<li>${item}</li>`).join('')}</ul>
+                </div>
+            </div>
+        </div>
+    `;
+}
+
+async function handleProgressSubmit(event) {
+    event.preventDefault();
+    const reviewBtn = document.getElementById('reviewBtn');
+    const output = document.getElementById('progressOutput');
+
+    const payload = {
+        baseline_scores: {
+            listening: Number(document.getElementById('baselineListening').value),
+            speaking: Number(document.getElementById('baselineSpeaking').value),
+            reading: Number(document.getElementById('baselineReading').value),
+            writing: Number(document.getElementById('baselineWriting').value),
+        },
+        latest_scores: {
+            listening: Number(document.getElementById('latestListening').value),
+            speaking: Number(document.getElementById('latestSpeaking').value),
+            reading: Number(document.getElementById('latestReading').value),
+            writing: Number(document.getElementById('latestWriting').value),
+        },
+        weeks_elapsed: Number(document.getElementById('weeksElapsed').value),
+        total_logged_hours: Number(document.getElementById('loggedHours').value),
+        completed_mock_tests: Number(document.getElementById('mockCompleted').value),
+    };
+
+    reviewBtn.disabled = true;
+    reviewBtn.textContent = '分析中...';
+    output.style.display = 'block';
+    output.innerHTML = '正在分析学习进度，请稍候...';
+
+    try {
+        const response = await fetch('/api/ielts/progress/review', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+        });
+
+        if (!response.ok) {
+            const message = await response.text();
+            throw new Error(message || '生成复盘建议失败');
+        }
+
+        const data = await response.json();
+        renderProgressReview(data);
+    } catch (error) {
+        console.error(error);
+        output.innerHTML = `<span class="error">复盘失败：${error.message}</span>`;
+    } finally {
+        reviewBtn.disabled = false;
+        reviewBtn.textContent = '生成复盘建议';
+    }
+}
+
+function renderProgressReview(data) {
+    const output = document.getElementById('progressOutput');
+
+    const improvementList = Object.entries(data.score_improvements)
+        .map(([skill, delta]) => `<li>${skillLabels[skill] || skill}：${delta >= 0 ? '+' : ''}${delta}</li>`)
+        .join('');
+
+    output.innerHTML = `
+        <div class="plan-meta">
+            <div>
+                <span class="meta-title">完成周数</span>
+                <strong>${data.weeks_elapsed}</strong>
+            </div>
+            <div>
+                <span class="meta-title">累计时长</span>
+                <strong>${data.total_logged_hours} h</strong>
+            </div>
+            <div>
+                <span class="meta-title">当前弱项</span>
+                <strong>${skillLabels[data.weakest_skill] || data.weakest_skill}</strong>
+            </div>
+            <div>
+                <span class="meta-title">建议阶段</span>
+                <strong>${data.suggested_next_stage.toUpperCase()}</strong>
+            </div>
+        </div>
+        <div class="plan-section">
+            <h3>分数变化</h3>
+            <ul>${improvementList}</ul>
+        </div>
+        <div class="plan-section">
+            <h3>下一步重点</h3>
+            <p>优先关注：${data.focus_recommendations
+                .map((skill) => skillLabels[skill] || skill)
+                .join('、')}</p>
+            <ul>${data.next_actions.map((item) => `<li>${item}</li>`).join('')}</ul>
+        </div>
+        <div class="plan-section">
+            <h3>模考建议</h3>
+            <p>已完成：${data.mock_test_suggestion.completed} 次</p>
+            <p>${data.mock_test_suggestion.next}</p>
+        </div>
+    `;
+}


### PR DESCRIPTION
## Summary
- add a dedicated FastAPI router for the IELTS study system with stage planning, supporting-tool, vocabulary and reporting endpoints
- register the new router in the modular backend and surface a full-featured IELTS learning workspace in the dashboard
- build a professional IELTS study interface covering personalized planning, module overviews, mock exams, vocabulary decks and progress reviews

## Testing
- `python -m compileall backend`

------
https://chatgpt.com/codex/tasks/task_e_68ce546d29d883329087c03b37219c86