### PR TITLE
Add interactive IELTS practice modules and feedback

### DIFF
--- a/frontend/features/ielts-study-system/index.html
+++ b/frontend/features/ielts-study-system/index.html
@@ -160,7 +160,24 @@
             </section>
 
             <section class="panel">
-                <h2>06. 架构与扩展</h2>
+                <h2>06. 互动训练实验室</h2>
+                <p>结合真实任务，直接完成听说读写练习并获取即时反馈，可在同一界面完成练习、提交答案与查看分析。</p>
+                <div class="practice-lab">
+                    <div class="practice-tabs" role="tablist">
+                        <button type="button" class="practice-tab active" data-skill="listening">听力训练</button>
+                        <button type="button" class="practice-tab" data-skill="reading">阅读练习</button>
+                        <button type="button" class="practice-tab" data-skill="speaking">口语演练</button>
+                        <button type="button" class="practice-tab" data-skill="writing">写作任务</button>
+                        <button type="button" class="practice-tab" data-skill="vocabulary">词汇测验</button>
+                    </div>
+                    <div id="practiceContent" class="practice-content">
+                        <p class="practice-note">选择上方技能即可开始互动练习。</p>
+                    </div>
+                </div>
+            </section>
+
+            <section class="panel">
+                <h2>07. 架构与扩展</h2>
                 <p>语音识别、语音合成与大语言模型服务均通过标准接口接入，可随时替换供应商；平台支持数据隔离与备份恢复。</p>
                 <div id="systemOverview" class="system-overview"></div>
             </section>
@@ -387,6 +404,194 @@
             grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
             gap: 16px;
             margin-top: 12px;
+        }
+        .practice-lab {
+            margin-top: 16px;
+            display: grid;
+            gap: 18px;
+        }
+        .practice-tabs {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+        .practice-tab {
+            border: 1px solid #d4dbe8;
+            background: #f5f8ff;
+            border-radius: 999px;
+            padding: 8px 18px;
+            font-size: 14px;
+            color: #475467;
+            cursor: pointer;
+            transition: background 0.2s ease;
+        }
+        .practice-tab.active {
+            background: #0b61c3;
+            color: #fff;
+            border-color: #0b61c3;
+        }
+        .practice-content {
+            border: 1px solid #dbe3f0;
+            border-radius: 12px;
+            background: #fff;
+            padding: 20px;
+        }
+        .practice-card {
+            display: grid;
+            gap: 20px;
+        }
+        .practice-note {
+            font-size: 13px;
+            color: #667085;
+        }
+        .transcript-box {
+            background: #f5f8ff;
+            border-radius: 10px;
+            padding: 16px;
+            max-height: 240px;
+            overflow-y: auto;
+        }
+        .transcript-line {
+            display: flex;
+            gap: 10px;
+            margin-bottom: 8px;
+            font-size: 14px;
+            color: #1f2937;
+        }
+        .transcript-speaker {
+            font-weight: 600;
+            color: #0f172a;
+            min-width: 80px;
+        }
+        .question-block {
+            margin-top: 12px;
+            padding: 14px;
+            border: 1px solid #e5e7eb;
+            border-radius: 10px;
+            background: #fdfefe;
+        }
+        .question-block h4 {
+            font-size: 15px;
+            margin-bottom: 10px;
+            color: #111827;
+        }
+        .option-row {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 6px;
+            font-size: 14px;
+            color: #374151;
+        }
+        .practice-actions {
+            display: flex;
+            justify-content: flex-end;
+            margin-top: 12px;
+        }
+        .practice-section {
+            margin-top: 12px;
+        }
+        .practice-section h4 {
+            font-size: 14px;
+            margin-bottom: 6px;
+            color: #1f2937;
+        }
+        .tips-list {
+            padding-left: 18px;
+            font-size: 14px;
+            color: #475467;
+        }
+        .tips-list li + li {
+            margin-top: 4px;
+        }
+        .reading-passage {
+            background: #f8fafc;
+            border-radius: 10px;
+            padding: 16px;
+            display: grid;
+            gap: 12px;
+            font-size: 14px;
+            line-height: 1.6;
+            color: #1f2937;
+        }
+        .result-summary {
+            font-weight: 600;
+            font-size: 15px;
+            color: #0f172a;
+        }
+        .breakdown-list {
+            margin-top: 10px;
+            padding-left: 18px;
+            font-size: 14px;
+            color: #374151;
+        }
+        .breakdown-list li.correct {
+            color: #047857;
+        }
+        .breakdown-list li.incorrect {
+            color: #b91c1c;
+        }
+        .practice-grid {
+            display: grid;
+            gap: 18px;
+            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        }
+        .writing-form {
+            display: grid;
+            gap: 12px;
+        }
+        .writing-form textarea,
+        #speakingTranscript {
+            width: 100%;
+            border-radius: 10px;
+            border: 1px solid #d0d5dd;
+            padding: 12px;
+            font-size: 14px;
+            resize: vertical;
+            min-height: 160px;
+            color: #1f2937;
+        }
+        .timer-row {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            margin-top: 8px;
+        }
+        .timer-display {
+            font-size: 18px;
+            font-weight: 600;
+            color: #0f172a;
+            min-width: 80px;
+        }
+        .timer-btn {
+            border: 1px solid #bcd4f6;
+            background: #e8f3ff;
+            color: #0b61c3;
+            border-radius: 8px;
+            padding: 6px 12px;
+            cursor: pointer;
+            transition: background 0.2s ease;
+        }
+        .timer-btn:hover {
+            background: #d7e8ff;
+        }
+        .feedback-grid {
+            display: grid;
+            gap: 14px;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        }
+        .feedback-card {
+            background: #f8fafc;
+            border: 1px solid #e2e8f0;
+            border-radius: 10px;
+            padding: 14px;
+            font-size: 14px;
+            color: #1f2937;
+        }
+        .feedback-card h4 {
+            margin-bottom: 8px;
+            font-size: 14px;
+            color: #0f172a;
         }
         .error {
             color: #c53030;

--- a/frontend/features/ielts-study-system/script.js
+++ b/frontend/features/ielts-study-system/script.js
@@ -10,6 +10,10 @@ const skillLabels = {
     writing: '写作',
 };
 
+let practiceData = null;
+let currentPracticeSkill = 'listening';
+let speakingTimerInterval = null;
+
 document.addEventListener('DOMContentLoaded', () => {
     initialisePage();
 });
@@ -22,6 +26,7 @@ async function initialisePage() {
         loadMockTests(),
         loadVocabularyDeck(),
         loadSystemOverview(),
+        loadPracticeLab(),
     ]);
 }
 
@@ -457,4 +462,585 @@ function renderProgressReview(data) {
             <p>${data.mock_test_suggestion.next}</p>
         </div>
     `;
+}
+
+
+async function loadPracticeLab() {
+    const container = document.getElementById('practiceContent');
+    if (!container) {
+        return;
+    }
+
+    container.innerHTML = '<p class="practice-note">正在加载互动练习，请稍候...</p>';
+
+    try {
+        const response = await fetch('/api/ielts/interactive/practice');
+        if (!response.ok) throw new Error('无法获取互动练习内容');
+        practiceData = await response.json();
+        setupPracticeTabs();
+        renderPracticeView(currentPracticeSkill);
+    } catch (error) {
+        console.error(error);
+        container.innerHTML = `<p class="error">互动练习加载失败：${error.message}</p>`;
+    }
+}
+
+
+function setupPracticeTabs() {
+    const tabs = document.querySelectorAll('.practice-tab');
+    tabs.forEach((tab) => {
+        tab.addEventListener('click', () => {
+            if (tab.classList.contains('active')) {
+                return;
+            }
+            tabs.forEach((btn) => btn.classList.remove('active'));
+            tab.classList.add('active');
+            currentPracticeSkill = tab.dataset.skill;
+            renderPracticeView(currentPracticeSkill);
+        });
+    });
+}
+
+
+function renderPracticeView(skill) {
+    const container = document.getElementById('practiceContent');
+    if (!container) {
+        return;
+    }
+    if (!practiceData) {
+        container.innerHTML = '<p class="practice-note">正在准备练习数据...</p>';
+        return;
+    }
+
+    const data = practiceData[skill];
+    if (!data) {
+        container.innerHTML = '<p class="error">该练习暂未上线，稍后再试。</p>';
+        return;
+    }
+
+    switch (skill) {
+        case 'listening':
+            renderListeningPractice(data);
+            break;
+        case 'reading':
+            renderReadingPractice(data);
+            break;
+        case 'vocabulary':
+            renderVocabularyPractice(data);
+            break;
+        case 'writing':
+            renderWritingPractice(data);
+            break;
+        case 'speaking':
+            renderSpeakingPractice(data);
+            break;
+        default:
+            container.innerHTML = '<p class="error">暂不支持的练习类型。</p>';
+    }
+}
+
+
+function renderListeningPractice(data) {
+    const container = document.getElementById('practiceContent');
+    const transcript = (data.audio_script || [])
+        .map(
+            (line) => `
+            <div class="transcript-line">
+                <span class="transcript-speaker">${line.speaker}</span>
+                <span>${line.text}</span>
+            </div>
+        `,
+        )
+        .join('');
+
+    container.innerHTML = `
+        <div class="practice-card">
+            <div>
+                <h3>${data.title}</h3>
+                <p class="practice-note">${data.description}</p>
+                ${data.context ? `<p class="practice-note">练习提示：${data.context}</p>` : ''}
+            </div>
+            <div class="transcript-box">${transcript}</div>
+            <form id="listeningPracticeForm">
+                ${buildQuestionHtml(data)}
+                <div class="practice-actions">
+                    <button type="submit">提交答案</button>
+                </div>
+            </form>
+            <div id="listeningResult" class="result-box" style="display:none;"></div>
+        </div>
+    `;
+
+    const form = document.getElementById('listeningPracticeForm');
+    form.addEventListener('submit', (event) =>
+        handleMultipleChoiceSubmit(event, data, '/api/ielts/interactive/listening/evaluate', 'listeningResult'),
+    );
+}
+
+
+function renderReadingPractice(data) {
+    const container = document.getElementById('practiceContent');
+    const passage = (data.passage || [])
+        .map((paragraph) => `<p>${paragraph}</p>`)
+        .join('');
+
+    container.innerHTML = `
+        <div class="practice-card">
+            <div>
+                <h3>${data.title}</h3>
+                <p class="practice-note">${data.description}</p>
+            </div>
+            <div class="reading-passage">${passage}</div>
+            <form id="readingPracticeForm">
+                ${buildQuestionHtml(data)}
+                <div class="practice-actions">
+                    <button type="submit">提交答案</button>
+                </div>
+            </form>
+            <div id="readingResult" class="result-box" style="display:none;"></div>
+        </div>
+    `;
+
+    document.getElementById('readingPracticeForm').addEventListener('submit', (event) =>
+        handleMultipleChoiceSubmit(event, data, '/api/ielts/interactive/reading/evaluate', 'readingResult'),
+    );
+}
+
+
+function renderVocabularyPractice(data) {
+    const container = document.getElementById('practiceContent');
+    container.innerHTML = `
+        <div class="practice-card">
+            <div>
+                <h3>${data.title}</h3>
+                <p class="practice-note">${data.description}</p>
+            </div>
+            <form id="vocabularyPracticeForm">
+                ${buildQuestionHtml(data)}
+                <div class="practice-actions">
+                    <button type="submit">检查答案</button>
+                </div>
+            </form>
+            <div id="vocabularyResult" class="result-box" style="display:none;"></div>
+        </div>
+    `;
+
+    document.getElementById('vocabularyPracticeForm').addEventListener('submit', (event) =>
+        handleMultipleChoiceSubmit(event, data, '/api/ielts/interactive/vocabulary/evaluate', 'vocabularyResult'),
+    );
+}
+
+
+function renderWritingPractice(data) {
+    const container = document.getElementById('practiceContent');
+    const brainstorm = (data.brainstorm_points || [])
+        .map((item) => `<li>${item}</li>`)
+        .join('');
+    const structure = (data.structure || [])
+        .map((item) => `<li>${item}</li>`)
+        .join('');
+    const checklist = (data.checklist || [])
+        .map((item) => `<li>${item}</li>`)
+        .join('');
+    const phrases = (data.useful_phrases || [])
+        .map((item) => `<li>${item}</li>`)
+        .join('');
+
+    container.innerHTML = `
+        <div class="practice-card">
+            <div>
+                <h3>${data.task_type || 'Task 2'} 写作训练</h3>
+                <p><strong>题目：</strong>${data.question}</p>
+                <p class="practice-note">${data.background || ''}</p>
+            </div>
+            <div class="practice-grid">
+                <div class="practice-section">
+                    <h4>思路提示</h4>
+                    <ul class="tips-list">${brainstorm}</ul>
+                </div>
+                <div class="practice-section">
+                    <h4>段落结构</h4>
+                    <ul class="tips-list">${structure}</ul>
+                </div>
+                <div class="practice-section">
+                    <h4>Checklist</h4>
+                    <ul class="tips-list">${checklist}</ul>
+                </div>
+            </div>
+            <form id="writingPracticeForm" class="writing-form">
+                <label for="writingResponse">在下方输入你的英文回答：</label>
+                <textarea id="writingResponse" rows="8" placeholder="建议 250 词以上，完成后点击获取反馈"></textarea>
+                <div class="practice-actions">
+                    <button type="submit">获取写作反馈</button>
+                </div>
+            </form>
+            <div id="writingFeedback" class="result-box" style="display:none;"></div>
+            <div class="practice-section">
+                <h4>高分表达</h4>
+                <ul class="tips-list">${phrases}</ul>
+                <p class="practice-note">${(data.tips || []).join('，')}</p>
+            </div>
+        </div>
+    `;
+
+    document.getElementById('writingPracticeForm').addEventListener('submit', handleWritingFeedback);
+}
+
+
+function renderSpeakingPractice(data) {
+    const container = document.getElementById('practiceContent');
+    const part1 = (data.part1?.questions || [])
+        .map((item) => `<li>${item}</li>`)
+        .join('');
+    const starters = (data.part1?.sample_sentence_starters || [])
+        .map((item) => `<li>${item}</li>`)
+        .join('');
+    const part2Points = (data.part2?.bullet_points || [])
+        .map((item) => `<li>${item}</li>`)
+        .join('');
+    const part3Questions = (data.part3?.questions || [])
+        .map((item) => `<li>${item}</li>`)
+        .join('');
+    const part3Ideas = (data.part3?.idea_bank || [])
+        .map((item) => `<li>${item}</li>`)
+        .join('');
+
+    const prepSeconds = data.part2?.prep_seconds || 60;
+    const speakSeconds = data.part2?.speaking_seconds || 120;
+
+    container.innerHTML = `
+        <div class="practice-card">
+            <div>
+                <h3>${data.title}</h3>
+                <p class="practice-note">${data.part1?.description || ''}</p>
+            </div>
+            <div class="practice-grid">
+                <div class="practice-section">
+                    <h4>Part 1 热身</h4>
+                    <ul class="tips-list">${part1}</ul>
+                    <p class="practice-note">开头可以参考：</p>
+                    <ul class="tips-list">${starters}</ul>
+                </div>
+                <div class="practice-section">
+                    <h4>Part 2 话题卡</h4>
+                    <p>${data.part2?.task || ''}</p>
+                    <ul class="tips-list">${part2Points}</ul>
+                    <div class="timer-row">
+                        <button type="button" class="timer-btn" data-duration="${prepSeconds}" data-target="prepTimer">准备计时 (${prepSeconds}s)</button>
+                        <div class="timer-display" id="prepTimer">${formatSeconds(prepSeconds)}</div>
+                    </div>
+                    <div class="timer-row">
+                        <button type="button" class="timer-btn" data-duration="${speakSeconds}" data-target="speakTimer">答题计时 (${speakSeconds}s)</button>
+                        <div class="timer-display" id="speakTimer">${formatSeconds(speakSeconds)}</div>
+                    </div>
+                    <p class="practice-note">语言提示：${(data.part2?.language_tips || []).join('；')}</p>
+                    <p class="practice-note">结构示例：${(data.part2?.model_outline || []).join(' → ')}</p>
+                </div>
+                <div class="practice-section">
+                    <h4>Part 3 深度提问</h4>
+                    <ul class="tips-list">${part3Questions}</ul>
+                    <p class="practice-note">思路参考：</p>
+                    <ul class="tips-list">${part3Ideas}</ul>
+                </div>
+            </div>
+            <form id="speakingPracticeForm" class="writing-form">
+                <label for="speakingTranscript">练习后请记录要点或台词，系统将给出改进建议：</label>
+                <textarea id="speakingTranscript" rows="6" placeholder="可粘贴自己的口语稿或要点，便于生成反馈"></textarea>
+                <div class="practice-actions">
+                    <button type="submit">获取口语反馈</button>
+                </div>
+            </form>
+            <div id="speakingFeedback" class="result-box" style="display:none;"></div>
+        </div>
+    `;
+
+    container.querySelectorAll('.timer-btn').forEach((button) => {
+        button.addEventListener('click', () => {
+            const duration = Number(button.dataset.duration);
+            const target = document.getElementById(button.dataset.target);
+            startSpeakingTimer(duration, target);
+        });
+    });
+
+    document.getElementById('speakingPracticeForm').addEventListener('submit', handleSpeakingFeedback);
+}
+
+
+function buildQuestionHtml(practice) {
+    return (practice.questions || [])
+        .map((question, index) => {
+            const options = (question.options || [])
+                .map(
+                    (option, optionIdx) => `
+                    <label class="option-row">
+                        <input type="radio" name="${practice.id}-${question.id}" value="${option.key}" ${optionIdx === 0 ? 'required' : ''}>
+                        <span>${option.key}. ${option.text}</span>
+                    </label>
+                `,
+                )
+                .join('');
+
+            return `
+                <div class="question-block">
+                    <h4>${index + 1}. ${question.question}</h4>
+                    ${options}
+                </div>
+            `;
+        })
+        .join('');
+}
+
+
+async function handleMultipleChoiceSubmit(event, practice, endpoint, resultId) {
+    event.preventDefault();
+    const resultBox = document.getElementById(resultId);
+    resultBox.style.display = 'block';
+
+    const answers = (practice.questions || []).map((question) => {
+        const selector = `input[name="${practice.id}-${question.id}"]:checked`;
+        const selected = event.target.querySelector(selector);
+        return { question_id: question.id, answer: selected ? selected.value : '' };
+    });
+
+    if (answers.some((item) => !item.answer)) {
+        resultBox.innerHTML = '<span class="error">请完成所有题目后再提交。</span>';
+        return;
+    }
+
+    resultBox.innerHTML = '正在评估答案...';
+
+    try {
+        const response = await fetch(endpoint, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ answers }),
+        });
+        if (!response.ok) {
+            const message = await response.text();
+            throw new Error(message || '评估失败');
+        }
+        const data = await response.json();
+        renderMultipleChoiceResult(data, resultBox);
+    } catch (error) {
+        console.error(error);
+        resultBox.innerHTML = `<span class="error">${error.message}</span>`;
+    }
+}
+
+
+function renderMultipleChoiceResult(result, container) {
+    const breakdown = (result.breakdown || [])
+        .map((item) => `
+            <li class="${item.correct ? 'correct' : 'incorrect'}">
+                <strong>${item.question}</strong><br>
+                ${item.correct ? '回答正确！' : `正确答案：${item.correct_answer}`}
+                ${item.explanation ? `<div class="practice-note">${item.explanation}</div>` : ''}
+            </li>
+        `)
+        .join('');
+
+    const tips = (result.tips || []).map((tip) => `<li>${tip}</li>`).join('');
+    const nextSteps = (result.next_steps || []).map((step) => `<li>${step}</li>`).join('');
+
+    container.innerHTML = `
+        <div class="result-summary">得分：${result.score}/${result.total}（${result.percentage}%）</div>
+        <ul class="breakdown-list">${breakdown}</ul>
+        ${tips ? `<div class="practice-section"><h4>技巧提示</h4><ul class="tips-list">${tips}</ul></div>` : ''}
+        ${nextSteps ? `<div class="practice-section"><h4>下一步建议</h4><ul class="tips-list">${nextSteps}</ul></div>` : ''}
+    `;
+}
+
+
+async function handleWritingFeedback(event) {
+    event.preventDefault();
+    const textarea = document.getElementById('writingResponse');
+    const feedbackBox = document.getElementById('writingFeedback');
+    const content = textarea.value.trim();
+
+    if (content.length < 80) {
+        feedbackBox.style.display = 'block';
+        feedbackBox.innerHTML = '<span class="error">请至少输入一段完整的英文回答。</span>';
+        return;
+    }
+
+    feedbackBox.style.display = 'block';
+    feedbackBox.innerHTML = '正在生成写作反馈...';
+
+    try {
+        const response = await fetch('/api/ielts/interactive/writing/feedback', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ response: content }),
+        });
+        if (!response.ok) {
+            const message = await response.text();
+            throw new Error(message || '获取写作反馈失败');
+        }
+        const data = await response.json();
+        renderWritingFeedback(data, feedbackBox);
+    } catch (error) {
+        console.error(error);
+        feedbackBox.innerHTML = `<span class="error">${error.message}</span>`;
+    }
+}
+
+
+function renderWritingFeedback(data, container) {
+    const strengths = (data.strengths && data.strengths.length ? data.strengths : ['继续保持稳定的论证结构。'])
+        .map((item) => `<li>${item}</li>`)
+        .join('');
+    const improvements = (data.improvements && data.improvements.length
+        ? data.improvements
+        : ['尝试加入更多例证并使用高级衔接词。'])
+        .map((item) => `<li>${item}</li>`)
+        .join('');
+
+    const connectorText = data.connectors && data.connectors.length ? data.connectors.join(', ') : '建议补充衔接词';
+    const academicText = data.academic_vocabulary && data.academic_vocabulary.length
+        ? data.academic_vocabulary.join(', ')
+        : '可增加学术词汇';
+
+    container.innerHTML = `
+        <div class="feedback-grid">
+            <div class="feedback-card">
+                <h4>字数与结构</h4>
+                <p>总词数：${data.word_count}</p>
+                <p>句子数：${data.sentence_count}</p>
+                <p>平均句长：${data.average_sentence_length}</p>
+                <p>段落数：${data.paragraphs}</p>
+            </div>
+            <div class="feedback-card">
+                <h4>词汇表现</h4>
+                <p>词汇多样性：${data.lexical_density}</p>
+                <p>衔接词：${connectorText}</p>
+                <p>学术词汇：${academicText}</p>
+            </div>
+            <div class="feedback-card">
+                <h4>预估分档</h4>
+                <p>Band 预测：${data.band_projection}</p>
+                <p class="practice-note">估算仅供参考，请结合官方评分标准。</p>
+            </div>
+        </div>
+        <div class="practice-section">
+            <h4>亮点</h4>
+            <ul class="tips-list">${strengths}</ul>
+        </div>
+        <div class="practice-section">
+            <h4>改进建议</h4>
+            <ul class="tips-list">${improvements}</ul>
+        </div>
+        <div class="practice-section">
+            <h4>Checklist 自查</h4>
+            <ul class="tips-list">${(data.checklist || []).map((item) => `<li>${item}</li>`).join('')}</ul>
+        </div>
+    `;
+}
+
+
+async function handleSpeakingFeedback(event) {
+    event.preventDefault();
+    const textarea = document.getElementById('speakingTranscript');
+    const feedbackBox = document.getElementById('speakingFeedback');
+    const content = textarea.value.trim();
+
+    if (content.length < 60) {
+        feedbackBox.style.display = 'block';
+        feedbackBox.innerHTML = '<span class="error">请至少记录完整的口语要点或稿件。</span>';
+        return;
+    }
+
+    feedbackBox.style.display = 'block';
+    feedbackBox.innerHTML = '正在分析口语表达...';
+
+    try {
+        const response = await fetch('/api/ielts/interactive/speaking/coach', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ transcript: content, focus_part: 'part2' }),
+        });
+        if (!response.ok) {
+            const message = await response.text();
+            throw new Error(message || '生成口语反馈失败');
+        }
+        const data = await response.json();
+        renderSpeakingFeedback(data, feedbackBox);
+    } catch (error) {
+        console.error(error);
+        feedbackBox.innerHTML = `<span class="error">${error.message}</span>`;
+    }
+}
+
+
+function renderSpeakingFeedback(data, container) {
+    const strengths = (data.strengths && data.strengths.length ? data.strengths : ['继续保持自然的语速与语音。'])
+        .map((item) => `<li>${item}</li>`)
+        .join('');
+    const improvements = (data.improvements && data.improvements.length
+        ? data.improvements
+        : ['尝试补充细节并使用更多衔接词。'])
+        .map((item) => `<li>${item}</li>`)
+        .join('');
+
+    const fillerUsage = data.filler_usage && data.filler_usage.length
+        ? `<ul class="tips-list">${data.filler_usage.map((item) => `<li>${item.term} × ${item.count}</li>`).join('')}</ul>`
+        : '<p class="practice-note">未检测到明显口头语。</p>';
+
+    container.innerHTML = `
+        <div class="feedback-grid">
+            <div class="feedback-card">
+                <h4>输出概览</h4>
+                <p>总词数：${data.word_count}</p>
+                <p>独立词数：${data.unique_words}</p>
+                <p>词汇多样性：${data.lexical_variety}</p>
+            </div>
+            <div class="feedback-card">
+                <h4>衔接与口头语</h4>
+                <p>衔接词：${data.connectors && data.connectors.length ? data.connectors.join(', ') : '建议补充衔接词'}</p>
+                ${fillerUsage}
+            </div>
+            <div class="feedback-card">
+                <h4>预估分档</h4>
+                <p>Band 预测：${data.band_projection}</p>
+                <p class="practice-note">结合流利度、词汇与连贯性估算，仅供参考。</p>
+            </div>
+        </div>
+        <div class="practice-section">
+            <h4>亮点</h4>
+            <ul class="tips-list">${strengths}</ul>
+        </div>
+        <div class="practice-section">
+            <h4>改进建议</h4>
+            <ul class="tips-list">${improvements}</ul>
+        </div>
+        ${data.follow_up_prompts && data.follow_up_prompts.length
+            ? `<div class="practice-section"><h4>延展练习</h4><ul class="tips-list">${data.follow_up_prompts.map((item) => `<li>${item}</li>`).join('')}</ul></div>`
+            : ''}
+    `;
+}
+
+
+function startSpeakingTimer(duration, displayElement) {
+    if (!displayElement) {
+        return;
+    }
+    clearInterval(speakingTimerInterval);
+    let remaining = duration;
+    displayElement.textContent = formatSeconds(remaining);
+
+    speakingTimerInterval = setInterval(() => {
+        remaining -= 1;
+        if (remaining <= 0) {
+            clearInterval(speakingTimerInterval);
+            displayElement.textContent = '00:00';
+            return;
+        }
+        displayElement.textContent = formatSeconds(remaining);
+    }, 1000);
+}
+
+
+function formatSeconds(value) {
+    const minutes = String(Math.floor(value / 60)).padStart(2, '0');
+    const seconds = String(value % 60).padStart(2, '0');
+    return `${minutes}:${seconds}`;
 }


### PR DESCRIPTION
## Summary
- add interactive practice data sets and evaluation endpoints covering listening, reading, vocabulary, writing and speaking feedback
- surface a new interactive IELTS lab in the frontend with skill tabs, answer submission and instant feedback rendering
- update feature styling to support transcripts, timers and feedback cards used by the new practice tools

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce6c4960f0833284ec3784230f1788