### PR TITLE
Add audio playback and AI-powered feedback to IELTS lab

### DIFF
--- a/backend/features/ielts_study_system/router.py
+++ b/backend/features/ielts_study_system/router.py
@@ -504,6 +504,14 @@ LISTENING_PRACTICE = {
     "title": "公共交通咨询",
     "description": "模拟雅思听力 Section 1：新生向公交中心咨询最划算的票种与班车时间。",
     "context": "建议先浏览题目关键词，再带着问题听/读对话。",
+    "audio_summary": "Student 和交通服务人员讨论月票、首班车时间以及机场班车预订要求的对话。",
+    "audio_duration_seconds": 85,
+    "key_phrases": [
+        {"phrase": "student monthly pass", "note": "学生月票，工作日与周末均可无限次乘坐"},
+        {"phrase": "first bus at 6:15 a.m.", "note": "工作日首班车时间"},
+        {"phrase": "shuttle every Saturday 8 a.m.", "note": "机场班车发车频率"},
+        {"phrase": "book at least two days in advance", "note": "预约班车需要提前两天"},
+    ],
     "audio_script": [
         {
             "speaker": "Student",

--- a/frontend/features/ielts-study-system/index.html
+++ b/frontend/features/ielts-study-system/index.html
@@ -596,6 +596,164 @@
         .error {
             color: #c53030;
         }
+        .listening-card {
+            gap: 16px;
+        }
+        .listening-header h3 {
+            margin-bottom: 4px;
+        }
+        .listening-audio-box {
+            border: 1px solid #dbe3f5;
+            background: #f6f9ff;
+            border-radius: 10px;
+            padding: 14px 16px;
+            display: grid;
+            gap: 12px;
+        }
+        .audio-box-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+        }
+        .audio-box-header h4 {
+            margin: 0;
+            font-size: 15px;
+            color: #0f172a;
+        }
+        .audio-duration {
+            font-size: 12px;
+            color: #475467;
+        }
+        .listening-audio {
+            width: 100%;
+        }
+        .audio-button-group {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+        .audio-button-group button {
+            background: #0b61c3;
+            color: #fff;
+            border: none;
+            border-radius: 8px;
+            padding: 8px 16px;
+            cursor: pointer;
+            font-size: 14px;
+            transition: opacity 0.2s ease;
+        }
+        .audio-button-group button:hover:not(.disabled) {
+            opacity: 0.88;
+        }
+        .audio-button-group button.disabled {
+            background: #d1d5db;
+            color: #6b7280;
+            cursor: not-allowed;
+        }
+        .audio-note {
+            margin: 0;
+        }
+        .key-phrase-section {
+            margin-top: 0;
+        }
+        .key-phrase-list {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+        }
+        .key-phrase-pill {
+            display: inline-flex;
+            flex-direction: column;
+            gap: 2px;
+            padding: 8px 12px;
+            border-radius: 8px;
+            background: #eef4ff;
+            border: 1px solid #c8d9ff;
+            color: #1f2937;
+            font-size: 13px;
+        }
+        .key-phrase-pill strong {
+            font-weight: 600;
+            color: #0f172a;
+        }
+        .key-phrase-note {
+            font-size: 12px;
+            color: #475467;
+        }
+        .transcript-toggle {
+            display: flex;
+            justify-content: flex-end;
+        }
+        .transcript-toggle button {
+            border: 1px solid #bcd4f6;
+            background: #eef4ff;
+            color: #0b61c3;
+            border-radius: 8px;
+            padding: 6px 12px;
+            font-size: 13px;
+            cursor: pointer;
+        }
+        .transcript-toggle button:hover {
+            background: #dce8ff;
+        }
+        .transcript-box.collapsed {
+            display: none;
+        }
+        .ai-coach-block {
+            margin-top: 16px;
+            padding-top: 16px;
+            border-top: 1px dashed #d4dbe8;
+        }
+        .ai-coach-btn {
+            background: #1f4bd8;
+            color: #fff;
+            border: none;
+            border-radius: 8px;
+            padding: 8px 18px;
+            cursor: pointer;
+            font-size: 14px;
+            transition: background 0.2s ease;
+        }
+        .ai-coach-btn:hover {
+            background: #163bb0;
+        }
+        .ai-coach-btn:disabled {
+            opacity: 0.6;
+            cursor: not-allowed;
+        }
+        .ai-coach-output {
+            margin-top: 12px;
+            background: #f6f8ff;
+            border: 1px solid #d6dcff;
+            border-radius: 10px;
+            padding: 14px 16px;
+            font-size: 14px;
+            color: #1f2937;
+            line-height: 1.65;
+        }
+        .ai-coach-output h3,
+        .ai-coach-output h4,
+        .ai-coach-output h5 {
+            margin-top: 10px;
+            margin-bottom: 6px;
+            font-size: 15px;
+            color: #0f172a;
+        }
+        .ai-coach-output ul,
+        .ai-coach-output ol {
+            padding-left: 20px;
+            margin: 8px 0;
+        }
+        .ai-coach-output code {
+            background: #e6ecff;
+            padding: 2px 4px;
+            border-radius: 4px;
+            font-size: 13px;
+        }
+        .ai-coach-output p {
+            margin: 6px 0;
+        }
         @media (max-width: 720px) {
             .ielts-container header {
                 flex-direction: column;


### PR DESCRIPTION
## Summary
- add audio metadata and scene keywords to the IELTS listening practice payload
- enhance the listening interaction card with browser speech playback, transcript toggling, and key phrase hints
- introduce a Gemini-powered AI coach for multiple-choice results with new UI styling for guidance output

## Testing
- python -m compileall backend/features/ielts_study_system/router.py

------
https://chatgpt.com/codex/tasks/task_e_68ce76b488a88332bc2782393a267512