### PR TITLE
Fix IELTS upload to accept single file inputs

### DIFF
--- a/backend/features/ielts_study_system/router.py
+++ b/backend/features/ielts_study_system/router.py
@@ -661,11 +661,16 @@ def _public_session_payload(session: Dict[str, object]) -> Dict[str, object]:
 
 @router.post("/upload-batch")
 async def create_session(
-    files: List[UploadFile] | None = File(default=None),
+    files: UploadFile | List[UploadFile] | None = File(default=None),
     manual_words: Optional[str] = Form(default=None),
     scenario_hint: Optional[str] = Form(default=None),
 ) -> Dict[str, object]:
-    uploads = files or []
+    if files is None:
+        uploads: List[UploadFile] = []
+    elif isinstance(files, list):
+        uploads = files
+    else:
+        uploads = [files]
     manual_tokens = _parse_manual_words(manual_words)
 
     if not uploads and not manual_tokens:


### PR DESCRIPTION
## Summary
- normalise the IELTS upload endpoint input so a single `UploadFile` is accepted as a list internally
- keep downstream processing unchanged while still supporting manual word input

## Testing
- python - <<'PY'
import os, sys
sys.path.append(os.path.join(os.getcwd(), 'backend'))
from main import app
from fastapi.testclient import TestClient

client = TestClient(app)

files = {'files': ('test.txt', b'hello world', 'text/plain')}
response = client.post('/api/ielts/upload-batch', files=files)
print(response.status_code)
print(response.json())
PY

------
https://chatgpt.com/codex/tasks/task_e_68cf9c6abf288332b57d7b1b60edabef