### PR TITLE
Fix listening audio format and add guided speaking coach

### DIFF
--- a/backend/features/ielts_study_system/router.py
+++ b/backend/features/ielts_study_system/router.py
@@ -60,7 +60,7 @@ class TTSSynthesizer:
         if not self.available or self._engine is None:
             return None, self._note
 
-        tmp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".mp3")
+        tmp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".wav")
         tmp_file.close()
         try:
             with self._lock:
@@ -537,7 +537,7 @@ def _prepare_listening_payload(
     audio_b64, tts_note = TTS_SYNTHESIZER.synthesize(script)
     audio_plan = {
         "available": audio_b64 is not None,
-        "format": "audio/mp3" if audio_b64 else None,
+        "format": "audio/wav" if audio_b64 else None,
         "base64": audio_b64,
         "message": tts_note,
     }
@@ -618,6 +618,8 @@ def _prepare_conversation_payload(conversation_raw: Dict[str, object], story: Di
                 "question": item.get("question") or "",
                 "focus_words": item.get("focus_words") or [],
                 "follow_up": item.get("follow_up") or "",
+                "reference_answer": item.get("reference_answer") or "",
+                "answer_explanation": item.get("answer_explanation") or "",
             }
         )
     agenda = conversation_raw.get("agenda")
@@ -661,9 +663,9 @@ def _prepare_conversation_payload(conversation_raw: Dict[str, object], story: Di
     practice_tips = conversation_raw.get("practice_tips")
     if not isinstance(practice_tips, list) or not practice_tips:
         practice_tips = [
-            "使用浏览器 SpeechSynthesis API 可快速生成每个问题的语音播放。",
-            "结合 MediaRecorder 录音，完成后上传到语音批改服务。",
-            "回答时务必包含列表中的每个词汇，可在末尾自检是否覆盖。",
+            "点击或按住下方按钮即可开始语音回答，浏览器会自动转写文字。",
+            "如果识别不稳定，可在放开按钮后手动修改文本再提交。",
+            "确保回答覆盖提示中的重点词汇，并按照追问提示进一步展开。",
         ]
     conversation = {
         "role": conversation_raw.get("role")
@@ -704,7 +706,7 @@ def _build_materials_prompt(words: List[str], scenario_hint: Optional[str]) -> s
         "  },\n"
         "  \"conversation\": {\n"
         "    \"role\": str, \"opening_line\": str, \"closing_line\": str,\n"
-        "    \"questions\": [{\"id\": str, \"question\": str, \"focus_words\": [str], \"follow_up\": str}],\n"
+        "    \"questions\": [{\"id\": str, \"question\": str, \"focus_words\": [str], \"follow_up\": str, \"reference_answer\": str, \"answer_explanation\": str}],\n"
         "    \"agenda\": [{\"step\": int, \"goal\": str, \"actions\": [str]}],\n"
         "    \"voice_prompts\": [{\"order\": int, \"text\": str, \"focus_words\": [str]}],\n"
         "    \"practice_tips\": [str]\n"

--- a/frontend/features/ielts-study-system/index.html
+++ b/frontend/features/ielts-study-system/index.html
@@ -127,7 +127,7 @@
                     <span id="conversationStatus" class="status-pill">等待生成</span>
                 </div>
                 <div id="conversationContent" class="module-content">
-                    <p class="placeholder">生成会话脚本后，可用浏览器语音合成朗读问题，配合录音练习口语输出。</p>
+                    <p class="placeholder">生成会话脚本后，AI 会逐题提问，你可以按住按钮回答并立即获得反馈。</p>
                 </div>
             </section>
         </main>
@@ -412,27 +412,171 @@
             padding: 12px;
             background: #fbfdff;
         }
-        .voice-row {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            gap: 12px;
-            padding: 12px 14px;
-            border-radius: 10px;
-            border: 1px solid #e2e8f0;
-            margin-bottom: 10px;
-            background: #fff;
+        .coach-wrapper {
+            margin-top: 12px;
+            padding: 16px;
+            border-radius: 14px;
+            border: 1px solid #d3def8;
+            background: linear-gradient(180deg, #fdfefe 0%, #f6faff 100%);
+            display: grid;
+            gap: 16px;
         }
-        .voice-row button {
-            padding: 6px 12px;
-            border-radius: 6px;
-            background: #3142c6;
-            color: #fff;
-            border: none;
+        .coach-header {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 12px;
+        }
+        .coach-question-label {
+            font-size: 0.85rem;
+            color: #4a4f75;
+            font-weight: 600;
+        }
+        .coach-question-text {
+            flex: 1;
+            min-width: 220px;
+        }
+        .coach-question-main {
+            font-weight: 600;
+            line-height: 1.5;
+            color: #2f3d63;
+        }
+        .coach-question-text .hint {
+            margin-top: 6px;
+            font-size: 0.85rem;
+            color: #4a4f75;
+        }
+        .coach-repeat {
+            padding: 6px 14px;
+            border-radius: 999px;
+            border: 1px solid #c5d4ff;
+            background: #f1f4ff;
+            color: #3142c6;
+            font-weight: 600;
             cursor: pointer;
         }
-        .voice-row button:hover {
-            background: #202fb8;
+        .coach-repeat:hover {
+            background: #e4eaff;
+        }
+        .coach-body {
+            display: grid;
+            gap: 10px;
+        }
+        .coach-transcript {
+            min-height: 24px;
+            font-size: 0.95rem;
+            color: #2f3d63;
+        }
+        .coach-feedback {
+            min-height: 36px;
+        }
+        .coach-feedback-success {
+            padding: 10px 12px;
+            border-radius: 10px;
+            background: #e8f8ef;
+            border: 1px solid #b6edc9;
+            color: #0f8d3a;
+        }
+        .coach-feedback-error {
+            padding: 10px 12px;
+            border-radius: 10px;
+            background: #fff3f0;
+            border: 1px solid #ffd1c7;
+            color: #d93025;
+        }
+        .coach-reference {
+            margin-top: 8px;
+            font-size: 0.9rem;
+            color: #2f3d63;
+        }
+        .coach-reference mark {
+            background: #fff0b3;
+            border-radius: 4px;
+            padding: 0 4px;
+        }
+        .push-to-talk {
+            justify-self: flex-start;
+            padding: 10px 22px;
+            border-radius: 999px;
+            border: none;
+            background: linear-gradient(135deg, #3142c6, #5a6dff);
+            color: #fff;
+            font-weight: 600;
+            cursor: pointer;
+            transition: transform 0.1s ease, box-shadow 0.2s ease;
+        }
+        .push-to-talk:hover {
+            transform: translateY(-1px);
+            box-shadow: 0 10px 18px rgba(49, 66, 198, 0.18);
+        }
+        .push-to-talk.recording {
+            background: linear-gradient(135deg, #d93025, #ff6b55);
+            box-shadow: 0 0 0 4px rgba(217, 48, 37, 0.18);
+        }
+        .push-to-talk:disabled {
+            background: #d6dcff;
+            color: #6b7bd6;
+            cursor: not-allowed;
+            box-shadow: none;
+        }
+        .manual-answer {
+            display: grid;
+            gap: 8px;
+        }
+        .manual-answer textarea {
+            width: 100%;
+            border-radius: 8px;
+            border: 1px solid #cbd5f5;
+            padding: 8px 10px;
+            font-size: 0.95rem;
+            resize: vertical;
+        }
+        .coach-manual-submit {
+            justify-self: flex-start;
+            padding: 6px 14px;
+            border-radius: 8px;
+            border: 1px solid #cdd9ff;
+            background: #f4f7ff;
+            color: #3142c6;
+            font-weight: 600;
+            cursor: pointer;
+        }
+        .coach-manual-submit:disabled {
+            opacity: 0.6;
+            cursor: not-allowed;
+        }
+        .coach-progress {
+            display: flex;
+            gap: 8px;
+            list-style: none;
+            padding: 0;
+            margin: 0;
+        }
+        .coach-progress li {
+            flex: 1;
+            min-width: 48px;
+            text-align: center;
+            padding: 6px 0;
+            border-radius: 8px;
+            background: #eef2ff;
+            color: #4150c8;
+            font-weight: 600;
+            font-size: 0.85rem;
+            transition: background 0.2s ease, color 0.2s ease;
+        }
+        .coach-progress li.complete {
+            background: #d7f5e0;
+            color: #0f8d3a;
+        }
+        .coach-progress li.active {
+            background: #3142c6;
+            color: #fff;
+        }
+        .coach-progress li span {
+            display: block;
+        }
+        .coach-closing {
+            min-height: 20px;
         }
         .evaluation-box {
             margin-top: 16px;


### PR DESCRIPTION
## Summary
- switch the pyttsx3 output to WAV so the generated listening audio plays reliably in browsers
- redesign the speaking section with a guided push-to-talk workflow, speech recognition handling, and richer feedback using model reference answers
- update the IELTS study page styling and copy to support the new guided experience

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68cfbe2376788332a4abb7f9703e3240