### PR TITLE
feat: update IELTS study flow for audio and conversation

### DIFF
--- a/frontend/features/ielts-study-system/index.html
+++ b/frontend/features/ielts-study-system/index.html
@@ -521,6 +521,11 @@
         .coach-feedback {
             min-height: 36px;
         }
+        .coach-feedback-hint {
+            margin-top: 6px;
+            font-size: 0.9rem;
+            color: #4a4f75;
+        }
         .coach-feedback-success {
             padding: 10px 12px;
             border-radius: 10px;
@@ -535,6 +540,24 @@
             border: 1px solid #ffd1c7;
             color: #d93025;
         }
+        .coach-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+            align-items: center;
+        }
+        .coach-reference-btn {
+            padding: 10px 16px;
+            border-radius: 10px;
+            border: 1px solid #d3def8;
+            background: #ffffff;
+            color: #3142c6;
+            font-weight: 600;
+            cursor: pointer;
+        }
+        .coach-reference-btn:hover {
+            background: #f2f5ff;
+        }
         .coach-reference {
             margin-top: 8px;
             font-size: 0.9rem;
@@ -544,6 +567,19 @@
             background: #fff0b3;
             border-radius: 4px;
             padding: 0 4px;
+        }
+        .coach-reference-panel {
+            min-height: 24px;
+            font-size: 0.9rem;
+            color: #2f3d63;
+        }
+        .coach-improved {
+            margin-top: 8px;
+            padding: 10px 12px;
+            border-radius: 10px;
+            background: #f2f7ff;
+            border: 1px solid #c5d4ff;
+            color: #2f3d63;
         }
         .api-key-control {
             display: flex;


### PR DESCRIPTION
## Summary
- derive listening scripts directly from the generated story, reuse them for TTS, and always build five comprehension questions for listening and reading
- enrich the conversation materials with control metadata, a reference-aware fallback, and a Gemini-powered evaluation endpoint
- refresh the front-end conversation experience with the new answer/reference buttons, LLM-based feedback, and improved styling for guidance panels

## Testing
- python -m compileall backend/features/ielts_study_system/router.py

------
https://chatgpt.com/codex/tasks/task_e_68d38897f23883328b17f9b939172614