### PR TITLE
feat: redesign IELTS study workflow

### DIFF
--- a/backend/features/ielts_study_system/router.py
+++ b/backend/features/ielts_study_system/router.py
@@ -1479,10 +1479,13 @@ def _evaluate_answers(
     answer_lookup = {item.question_id: item.answer for item in submission.answers}
     breakdown: List[Dict[str, object]] = []
     correct = 0
-    for question_id, meta in answer_bank.items():
+    evaluated = 0
+    for question_id, user_answer in answer_lookup.items():
+        if question_id not in answer_bank:
+            continue
+        meta = answer_bank[question_id]
         expected = meta["answer"]
         alternatives = {expected, *[alt for alt in meta.get("alternatives", [])]}
-        user_answer = answer_lookup.get(question_id, "")
         normalised_user = _normalise_answer(user_answer)
         candidates = {_normalise_answer(str(option)) for option in alternatives}
         is_correct = bool(normalised_user) and normalised_user in candidates
@@ -1497,7 +1500,8 @@ def _evaluate_answers(
                 "rationale": meta.get("rationale"),
             }
         )
-    total = len(answer_bank)
+        evaluated += 1
+    total = evaluated or len(answer_bank)
     accuracy = round(correct / total, 2) if total else 0.0
     return {
         "score": correct,

--- a/frontend/features/ielts-study-system/index.html
+++ b/frontend/features/ielts-study-system/index.html
@@ -3,102 +3,126 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>雅思情景化学习系统</title>
+    <title>IELTS 情景化学习系统</title>
     <link rel="stylesheet" href="../../style.css">
+    <link rel="stylesheet" href="./styles.css">
     <link rel="icon" href="../../public/favicon.ico">
 </head>
-<body>
-    <div class="feature-container ielts-container">
-        <header class="hero">
-            <div class="hero-copy">
-                <a class="back-link" href="../../dashboard.html">← 返回功能中心</a>
+<body class="ielts-theme">
+    <div class="feature-container ielts-app">
+        <header class="app-header">
+            <a class="back-link" href="../../dashboard.html">← 返回功能中心</a>
+            <div>
                 <h1>IELTS 情景化学习系统</h1>
-                <p class="intro">上传单词或实物照片，系统会自动识别关键词并生成对应的英语情景片段，让每个词汇都置于真实语境。</p>
-                <div class="hero-badges">
-                    <span class="hero-badge">Gemini OCR 驱动</span>
-                    <span class="hero-badge">情景故事生成</span>
-                    <span class="hero-badge">词汇记忆辅助</span>
-                </div>
+                <p>上传单词或实物照片，系统将自动提取核心词汇、生成情境故事与阅读练习，并通过 SRS 机制帮助你巩固记忆。</p>
             </div>
-            <div class="module-grid">
-                <div class="module-card accent-scenario">
-                    <span class="module-icon">🖼️</span>
-                    <div>
-                        <h3>图像识别</h3>
-                        <p>自动提取照片中的英文单词。</p>
-                    </div>
-                </div>
-                <div class="module-card accent-story">
-                    <span class="module-icon">📖</span>
-                    <div>
-                        <h3>情景故事</h3>
-                        <p>根据词汇构建连贯且易记的段落。</p>
-                    </div>
-                </div>
-                <div class="module-card accent-hint">
-                    <span class="module-icon">💡</span>
-                    <div>
-                        <h3>逐词提示</h3>
-                        <p>提供每个词的情景片段与用法线索。</p>
-                    </div>
-                </div>
-            </div>
+            <nav id="viewTabs" class="tab-nav" role="tablist">
+                <button type="button" data-route="home" class="is-active" role="tab" aria-selected="true">上传中心</button>
+                <button type="button" data-route="study" role="tab" aria-selected="false">学习页</button>
+                <button type="button" data-route="review" role="tab" aria-selected="false">复习页</button>
+            </nav>
         </header>
 
-        <main>
-            <section id="uploadPanel" class="panel upload-panel">
-                <div class="panel-header">
-                    <div>
-                        <h2>上传与生成</h2>
-                        <p>支持批量上传学习资料照片，可补充自定义词汇或情景提示，Gemini 将返回情景故事与逐词提示。</p>
-                    </div>
-                    <span id="uploadStatusFlag" class="status-flag">待开始</span>
-                </div>
-                <form id="uploadForm" class="form-grid" enctype="multipart/form-data">
-                    <div class="form-group form-group-full">
-                        <label for="wordImages">上传单词照片</label>
-                        <input type="file" id="wordImages" name="files" accept="image/*" multiple>
-                        <small class="form-tip">建议保持照片清晰、光线充足；如识别失败可在下方手动补充。</small>
-                    </div>
-                    <div class="form-group form-group-full">
-                        <label for="manualWords">手动补充词汇（可逗号或换行分隔）</label>
-                        <textarea id="manualWords" rows="3" placeholder="education, educator, anthropology..."></textarea>
-                    </div>
-                    <div class="form-group form-group-full">
-                        <label for="scenarioHint">情景提示（选填）</label>
-                        <input type="text" id="scenarioHint" placeholder="例如：校园迎新、研究所参观、职业规划会">
-                    </div>
-                    <div class="form-group form-group-full">
-                        <label for="geminiApiKey">Gemini API Key</label>
-                        <div class="api-key-control">
-                            <input type="password" id="geminiApiKey" placeholder="请输入 Gemini API Key" autocomplete="off" spellcheck="false">
-                            <label class="remember-key" for="rememberGeminiKey">
-                                <input type="checkbox" id="rememberGeminiKey">
-                                <span>在本地保存，下次自动填写</span>
-                            </label>
+        <main class="app-main">
+            <section id="viewHome" class="view view-active" data-view="home">
+                <div class="home-grid">
+                    <section class="panel upload-panel">
+                        <div class="panel-header">
+                            <h2>上传与生成</h2>
+                            <span id="uploadStatusBadge" class="badge">待开始</span>
                         </div>
-                        <small class="form-tip">仅保存在浏览器本地，用于调用 Gemini 生成情景素材。</small>
-                    </div>
-                    <div class="progress-wrapper" id="uploadProgressWrapper" style="display:none;">
-                        <div class="progress-bar"><span id="uploadProgressFill"></span></div>
-                        <span id="uploadProgressText">0%</span>
-                    </div>
-                    <div class="form-actions form-group-full">
-                        <button type="submit" id="uploadBtn">生成情景素材</button>
-                    </div>
-                    <div class="upload-feedback" id="uploadFeedback"></div>
-                </form>
-                <div id="uploadSummary" class="result-box" style="display:none;"></div>
+                        <p class="panel-subtitle">支持拖拽或选择上传，系统会在 2 秒内进入骨架屏生成状态。单张图片最大 10MB，仅支持 JPG / PNG。</p>
+                        <div id="uploadDropzone" class="upload-dropzone" role="button" tabindex="0" aria-label="上传学习图片">
+                            <div class="dropzone-icon">📤</div>
+                            <p>拖拽图片到此处，或
+                                <button type="button" id="pickFilesBtn">选择文件</button>
+                            </p>
+                            <p class="upload-tip">最多可同时上传 3 张图片，系统自动去重并生成学习会话。</p>
+                        </div>
+                        <input type="file" id="filePicker" accept="image/png,image/jpeg" multiple hidden>
+                        <div id="uploadProgressContainer" class="progress-container" aria-live="polite">
+                            <div class="progress-bar"><span id="uploadProgressFill"></span></div>
+                            <span id="uploadProgressText">0%</span>
+                        </div>
+                        <p id="uploadError" class="error-message" role="alert"></p>
+                        <div class="api-key-config">
+                            <label for="geminiApiKey">Gemini API Key</label>
+                            <div class="api-key-row">
+                                <input type="password" id="geminiApiKey" autocomplete="off" spellcheck="false" placeholder="输入 Gemini API Key">
+                                <label class="remember-key" for="rememberGeminiKey">
+                                    <input type="checkbox" id="rememberGeminiKey"> 记住
+                                </label>
+                            </div>
+                            <small class="upload-tip">密钥仅保存在本地浏览器，用于触发 Gemini 解析与生成。</small>
+                        </div>
+                    </section>
+
+                    <section class="panel recent-panel">
+                        <div class="panel-header">
+                            <h2>最近 10 张图片</h2>
+                            <span id="recentCount" class="badge">0</span>
+                        </div>
+                        <p class="panel-subtitle">上传后立即生成缩略图，便于快速回溯学习素材。</p>
+                        <div id="recentGrid" class="recent-grid" aria-live="polite"></div>
+                    </section>
+                </div>
             </section>
 
-            <section id="scenarioPanel" class="panel module-block accent-scenario-block">
-                <div class="panel-heading">
-                    <h2>情景片段展示</h2>
-                    <span id="scenarioStatus" class="status-pill">等待生成</span>
+            <section id="viewStudy" class="view" data-view="study" aria-hidden="true">
+                <div class="study-layout">
+                    <section class="panel image-panel">
+                        <div class="panel-header">
+                            <h2>原图预览</h2>
+                            <div class="badge" id="assetMeta">无图像</div>
+                        </div>
+                        <div class="image-toolbar">
+                            <div id="assetStrip" class="asset-strip" aria-label="图片列表"></div>
+                            <div id="zoomControls" class="zoom-controls" aria-label="缩放控制">
+                                <button type="button" data-zoom="out" aria-label="缩小">−</button>
+                                <button type="button" data-zoom="reset" aria-label="重置">⟳</button>
+                                <button type="button" data-zoom="in" aria-label="放大">＋</button>
+                            </div>
+                        </div>
+                        <div class="image-viewer">
+                            <div id="imageViewport" class="image-viewport">
+                                <div id="imageStage" class="image-stage">
+                                    <img id="studyImage" src="" alt="学习原图" hidden>
+                                    <div id="bboxLayer" class="bbox-layer"></div>
+                                </div>
+                                <div id="imagePlaceholder" class="image-placeholder">上传后将在此显示原图与词框。</div>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section class="panel detail-panel">
+                        <div class="panel-section word-section">
+                            <div class="panel-header">
+                                <h2>词卡列表</h2>
+                                <span id="wordCountBadge" class="badge">0</span>
+                            </div>
+                            <div id="wordCardList" class="word-list" aria-live="polite"></div>
+                        </div>
+                        <div class="panel-section reading-section">
+                            <div class="panel-header">
+                                <h2>阅读填空</h2>
+                                <span id="readingStatus" class="badge">未生成</span>
+                            </div>
+                            <div id="readingQuiz" class="reading-quiz" aria-live="polite"></div>
+                        </div>
+                    </section>
                 </div>
-                <div id="scenarioContent" class="module-content">
-                    <p class="placeholder">上传单词照片后，将自动生成情景故事和逐词提示。</p>
-                </div>
+            </section>
+
+            <section id="viewReview" class="view" data-view="review" aria-hidden="true">
+                <section class="panel review-panel">
+                    <div class="panel-header">
+                        <h2>SRS 复习清单</h2>
+                        <span id="reviewSummary" class="badge">今日 0 / 累积 0</span>
+                    </div>
+                    <p class="panel-subtitle">采用 0–5 级记忆曲线，对应复习间隔 [1d, 3d, 7d, 14d, 30d]，数据持久化于本地。</p>
+                    <div id="reviewList" class="review-list" aria-live="polite"></div>
+                    <p id="reviewOverflow" class="panel-note"></p>
+                </section>
             </section>
         </main>
     </div>
@@ -108,309 +132,5 @@
     <script src="../../models.js"></script>
     <script src="../../usage.js"></script>
     <script src="./script.js"></script>
-    <style>
-        body.ielts-theme {
-            background: #f5f7ff;
-        }
-        .hero {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-            gap: 28px;
-            padding: 32px;
-            margin-bottom: 32px;
-            border-radius: 24px;
-            background: linear-gradient(135deg, #4f5fff 0%, #7f8dff 40%, #f2f3ff 100%);
-            color: #fff;
-        }
-        .hero-copy .back-link {
-            color: rgba(255, 255, 255, 0.9);
-            font-weight: 500;
-            margin-bottom: 12px;
-            display: inline-block;
-        }
-        .hero h1 {
-            font-size: 2.2rem;
-            margin-bottom: 12px;
-        }
-        .hero .intro {
-            max-width: 520px;
-            line-height: 1.6;
-            margin-bottom: 16px;
-        }
-        .hero-badges {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 10px;
-        }
-        .hero-badge {
-            padding: 6px 14px;
-            border-radius: 999px;
-            background: rgba(255, 255, 255, 0.18);
-            backdrop-filter: blur(6px);
-            font-size: 0.85rem;
-        }
-        .module-grid {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
-            gap: 12px;
-        }
-        .module-card {
-            display: flex;
-            align-items: center;
-            gap: 12px;
-            padding: 16px;
-            border-radius: 18px;
-            color: #1f1f3d;
-            background: rgba(255, 255, 255, 0.92);
-            box-shadow: 0 10px 24px rgba(30, 42, 200, 0.16);
-        }
-        .module-card h3 {
-            margin: 0 0 6px;
-            font-size: 1.1rem;
-        }
-        .module-card p {
-            margin: 0;
-            font-size: 0.85rem;
-            color: rgba(31, 31, 61, 0.7);
-        }
-        .module-icon {
-            font-size: 1.8rem;
-        }
-        .accent-scenario { background: linear-gradient(135deg, #e5e9ff, #f5f7ff); }
-        .accent-story { background: linear-gradient(135deg, #fff1f6, #fff6fa); }
-        .accent-hint { background: linear-gradient(135deg, #e5fff4, #f5fffb); }
-        .upload-panel {
-            background: #fff;
-            border-radius: 18px;
-            box-shadow: 0 18px 36px rgba(79, 95, 255, 0.08);
-            padding: 28px;
-        }
-        .panel-header {
-            display: flex;
-            align-items: flex-start;
-            justify-content: space-between;
-            gap: 16px;
-            margin-bottom: 16px;
-        }
-        .panel-header p {
-            margin-top: 6px;
-            color: #4a4f75;
-        }
-        .status-flag {
-            padding: 6px 14px;
-            border-radius: 999px;
-            background: #f0f1ff;
-            color: #2f3dbf;
-            font-weight: 600;
-            font-size: 0.85rem;
-        }
-        .status-flag.loading { background: #eef2ff; color: #3142c6; }
-        .status-flag.success { background: #d7f5e0; color: #0f8d3a; }
-        .status-flag.error { background: #fde2e1; color: #d93025; }
-        .form-grid {
-            display: grid;
-            gap: 16px;
-        }
-        .form-group {
-            display: flex;
-            flex-direction: column;
-            gap: 8px;
-        }
-        .form-group-full {
-            grid-column: 1 / -1;
-        }
-        .form-group label {
-            font-weight: 600;
-            color: #2f3d63;
-        }
-        .form-group input,
-        .form-group textarea {
-            width: 100%;
-            border: 1px solid #cbd5f5;
-            border-radius: 8px;
-            padding: 10px 12px;
-            font-size: 0.95rem;
-        }
-        .form-tip {
-            font-size: 0.85rem;
-            color: #6670a0;
-        }
-        .api-key-control {
-            display: flex;
-            flex-direction: column;
-            gap: 10px;
-        }
-        .remember-key {
-            display: flex;
-            align-items: center;
-            gap: 6px;
-            font-size: 0.9rem;
-            color: #4a4f75;
-            cursor: pointer;
-            user-select: none;
-        }
-        .remember-key input {
-            width: 16px;
-            height: 16px;
-        }
-        .form-actions button {
-            padding: 12px 24px;
-            border-radius: 12px;
-            border: none;
-            background: linear-gradient(135deg, #4f5fff, #7a8aff);
-            color: #fff;
-            font-weight: 600;
-            cursor: pointer;
-            transition: transform 0.1s ease, box-shadow 0.2s ease;
-        }
-        .form-actions button:hover {
-            transform: translateY(-1px);
-            box-shadow: 0 12px 20px rgba(79, 95, 255, 0.18);
-        }
-        .progress-wrapper {
-            display: flex;
-            align-items: center;
-            gap: 12px;
-            margin: 10px 0;
-        }
-        .progress-bar {
-            flex: 1;
-            height: 8px;
-            border-radius: 999px;
-            background: #e5e7ff;
-            overflow: hidden;
-        }
-        .progress-bar span {
-            display: block;
-            width: 0%;
-            height: 100%;
-            background: linear-gradient(90deg, #4f5fff, #7a8aff);
-            transition: width 0.3s ease;
-        }
-        .upload-feedback {
-            margin-top: 8px;
-            min-height: 20px;
-            font-size: 0.9rem;
-            color: #2f3dbf;
-        }
-        .upload-feedback.error {
-            color: #d93025;
-        }
-        .upload-feedback.success {
-            color: #0f8d3a;
-        }
-        .module-block {
-            border-radius: 18px;
-            padding: 24px;
-            margin-top: 28px;
-            background: #fff;
-            box-shadow: 0 18px 36px rgba(79, 95, 255, 0.08);
-        }
-        .accent-scenario-block {
-            background: linear-gradient(135deg, #f3f5ff, #ffffff);
-        }
-        .module-block .panel-heading {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            margin-bottom: 16px;
-        }
-        .status-pill {
-            display: inline-flex;
-            align-items: center;
-            gap: 6px;
-            padding: 4px 12px;
-            border-radius: 999px;
-            font-size: 0.85rem;
-            background: #eef2ff;
-            color: #3142c6;
-        }
-        .status-pill.ready { background: #d7f5e0; color: #0f8d3a; }
-        .status-pill.waiting { background: #f4f4f5; color: #4a4a4a; }
-        .status-pill.error { background: #fde2e1; color: #d93025; }
-        .status-pill.loading::after {
-            content: "";
-            width: 8px;
-            height: 8px;
-            border-radius: 50%;
-            background: currentColor;
-            animation: pulse 1s infinite;
-        }
-        @keyframes pulse {
-            0%, 100% { opacity: 0.2; }
-            50% { opacity: 1; }
-        }
-        .module-content .placeholder {
-            color: #666;
-            padding: 12px 0;
-        }
-        .session-chip {
-            display: inline-flex;
-            align-items: center;
-            gap: 8px;
-            padding: 6px 12px;
-            background: #f2f7ff;
-            border-radius: 12px;
-            font-size: 0.85rem;
-            color: #2643a1;
-        }
-        .word-grid {
-            display: flex;
-            flex-wrap: wrap;
-            gap: 8px;
-            margin: 12px 0;
-        }
-        .word-chip {
-            padding: 4px 10px;
-            border-radius: 999px;
-            background: #f7fafc;
-            border: 1px solid #d6e4ff;
-            font-size: 0.9rem;
-        }
-        .meta-note {
-            font-size: 0.85rem;
-            color: #4a4f75;
-            margin-top: 6px;
-        }
-        .meta-note li {
-            margin-top: 4px;
-        }
-        .story-block {
-            display: grid;
-            gap: 10px;
-            padding: 16px;
-            border-radius: 16px;
-            background: rgba(255, 255, 255, 0.9);
-            border: 1px solid rgba(79, 95, 255, 0.12);
-        }
-        .story-overview {
-            color: #3a4374;
-        }
-        .segment-list {
-            margin-top: 16px;
-            display: grid;
-            gap: 10px;
-        }
-        .segment-item {
-            padding: 12px 14px;
-            border-radius: 12px;
-            background: #f9fafb;
-            border: 1px solid #e2e8f0;
-            font-size: 0.95rem;
-            color: #2f3d63;
-        }
-        .segment-item strong {
-            display: block;
-            margin-bottom: 6px;
-        }
-        @media (max-width: 768px) {
-            .hero {
-                padding: 24px;
-            }
-            .module-grid {
-                grid-template-columns: repeat(2, minmax(0, 1fr));
-            }
-        }
-    </style>
 </body>
 </html>

--- a/frontend/features/ielts-study-system/script.js
+++ b/frontend/features/ielts-study-system/script.js
@@ -1,194 +1,941 @@
 // frontend/features/ielts-study-system/script.js
-// 精简版雅思情景学习系统：仅保留图片识别与情景片段生成功能
+// IELTS 情景化学习系统 - 多视图学习与复习体验
+
+/* global checkAuth usageTracker */
 
 checkAuth();
 
-let currentSessionId = null;
-let sessionPayload = null;
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+const ACCEPTED_TYPES = new Set(['image/jpeg', 'image/png', 'image/jpg']);
+const ROUTES = ['home', 'study', 'review'];
+
+const STORAGE_KEYS = {
+    recentUploads: 'ieltsStudyRecentUploads',
+    favorites: 'ieltsStudyFavorites',
+    srs: 'ieltsStudySrsProgress',
+    geminiKey: 'ieltsStudyGeminiApiKey',
+    rememberKey: 'ieltsStudyRememberGeminiKey'
+};
+
+const MASTERY_INTERVALS = {
+    0: 0,
+    1: 1,
+    2: 3,
+    3: 7,
+    4: 14,
+    5: 30
+};
+
+const state = {
+    route: 'home',
+    uploading: false,
+    uploadProgress: 0,
+    uploadIndeterminate: false,
+    uploadError: '',
+    sessionId: '',
+    session: null,
+    assets: [],
+    selectedAssetId: null,
+    viewerTransforms: {},
+    wordCards: [],
+    favorites: new Set(),
+    readingQuestions: [],
+    readingResults: {},
+    recentUploads: [],
+    srs: { words: {} },
+    hoverWordId: null,
+    activeWordId: null,
+    studySkeletonActive: false,
+    lastSkeletonAt: 0
+};
+
+const elements = {};
+let dragState = null;
 let progressHideTimer = null;
 
-const GEMINI_KEY_STORAGE_KEY = 'ieltsStudyGeminiApiKey';
-const GEMINI_REMEMBER_STORAGE_KEY = 'ieltsStudyRememberGeminiKey';
-
-function readFromLocalStorage(key) {
-    try {
-        if (typeof window === 'undefined' || !window.localStorage) {
-            return null;
-        }
-        return window.localStorage.getItem(key);
-    } catch (err) {
-        return null;
-    }
-}
-
-function writeToLocalStorage(key, value) {
-    try {
-        if (typeof window === 'undefined' || !window.localStorage) {
-            return;
-        }
-        window.localStorage.setItem(key, value);
-    } catch (err) {
-        return;
-    }
-}
-
-function removeFromLocalStorage(key) {
-    try {
-        if (typeof window === 'undefined' || !window.localStorage) {
-            return;
-        }
-        window.localStorage.removeItem(key);
-    } catch (err) {
-        return;
-    }
-}
-
-function getStoredGeminiKey() {
-    const value = readFromLocalStorage(GEMINI_KEY_STORAGE_KEY);
-    return value || '';
-}
-
-function shouldRememberGeminiKey() {
-    return readFromLocalStorage(GEMINI_REMEMBER_STORAGE_KEY) === 'true';
-}
-
-function getActiveGeminiApiKey() {
-    const input = document.getElementById('geminiApiKey');
-    if (input && typeof input.value === 'string') {
-        const trimmed = input.value.trim();
-        if (trimmed) {
-            return trimmed;
-        }
-    }
-    return getStoredGeminiKey();
-}
-
-function persistGeminiKey(value) {
-    const trimmed = typeof value === 'string' ? value.trim() : '';
-    if (trimmed) {
-        writeToLocalStorage(GEMINI_KEY_STORAGE_KEY, trimmed);
-    } else {
-        removeFromLocalStorage(GEMINI_KEY_STORAGE_KEY);
-    }
-}
-
-function persistRememberPreference(remember) {
-    writeToLocalStorage(GEMINI_REMEMBER_STORAGE_KEY, remember ? 'true' : 'false');
-    if (!remember) {
-        removeFromLocalStorage(GEMINI_KEY_STORAGE_KEY);
-    }
-}
-
-function initialiseGeminiKeyControls() {
-    const apiInput = document.getElementById('geminiApiKey');
-    const rememberCheckbox = document.getElementById('rememberGeminiKey');
-    if (!apiInput || !rememberCheckbox) {
-        return;
-    }
-
-    const storedKey = getStoredGeminiKey();
-    let rememberPreference = shouldRememberGeminiKey();
-    if (storedKey && !rememberPreference) {
-        rememberPreference = true;
-        writeToLocalStorage(GEMINI_REMEMBER_STORAGE_KEY, 'true');
-    }
-
-    rememberCheckbox.checked = rememberPreference;
-    if (rememberPreference && storedKey) {
-        apiInput.value = storedKey;
-    }
-
-    rememberCheckbox.addEventListener('change', () => {
-        const shouldRemember = rememberCheckbox.checked;
-        persistRememberPreference(shouldRemember);
-        if (shouldRemember && apiInput.value.trim()) {
-            persistGeminiKey(apiInput.value);
-        }
-    });
-
-    apiInput.addEventListener('input', () => {
-        if (!rememberCheckbox.checked) {
-            return;
-        }
-        persistGeminiKey(apiInput.value);
-    });
-}
+const GEMINI_KEY_STORAGE_KEY = STORAGE_KEYS.geminiKey;
+const GEMINI_REMEMBER_STORAGE_KEY = STORAGE_KEYS.rememberKey;
 
 document.addEventListener('DOMContentLoaded', () => {
-    const form = document.getElementById('uploadForm');
-    if (form) {
-        form.addEventListener('submit', handleUploadSubmit);
-    }
+    cacheElements();
+    loadStoredState();
+    bindGlobalEvents();
+    restoreRouteFromHash();
     initialiseGeminiKeyControls();
-    setStatus('scenarioStatus', '等待生成', 'waiting');
-    if (document.body) {
-        document.body.classList.add('ielts-theme');
-    }
+    renderAll();
 });
 
-function setStatus(elementId, text, state) {
-    const pill = document.getElementById(elementId);
-    if (!pill) return;
-    pill.textContent = text;
-    pill.classList.remove('ready', 'waiting', 'error', 'loading');
-    if (state) {
-        pill.classList.add(state);
+function cacheElements() {
+    elements.viewSections = Array.from(document.querySelectorAll('.view'));
+    elements.tabNav = document.getElementById('viewTabs');
+    elements.uploadBadge = document.getElementById('uploadStatusBadge');
+    elements.dropZone = document.getElementById('uploadDropzone');
+    elements.fileInput = document.getElementById('filePicker');
+    elements.pickFilesBtn = document.getElementById('pickFilesBtn');
+    elements.progressContainer = document.getElementById('uploadProgressContainer');
+    elements.progressFill = document.getElementById('uploadProgressFill');
+    elements.progressText = document.getElementById('uploadProgressText');
+    elements.uploadError = document.getElementById('uploadError');
+    elements.recentGrid = document.getElementById('recentGrid');
+    elements.recentCount = document.getElementById('recentCount');
+    elements.assetStrip = document.getElementById('assetStrip');
+    elements.assetMeta = document.getElementById('assetMeta');
+    elements.imageViewport = document.getElementById('imageViewport');
+    elements.imageStage = document.getElementById('imageStage');
+    elements.studyImage = document.getElementById('studyImage');
+    elements.bboxLayer = document.getElementById('bboxLayer');
+    elements.imagePlaceholder = document.getElementById('imagePlaceholder');
+    elements.zoomControls = document.getElementById('zoomControls');
+    elements.wordList = document.getElementById('wordCardList');
+    elements.wordCountBadge = document.getElementById('wordCountBadge');
+    elements.readingQuiz = document.getElementById('readingQuiz');
+    elements.readingStatus = document.getElementById('readingStatus');
+    elements.reviewList = document.getElementById('reviewList');
+    elements.reviewSummary = document.getElementById('reviewSummary');
+    elements.reviewOverflow = document.getElementById('reviewOverflow');
+    elements.geminiInput = document.getElementById('geminiApiKey');
+    elements.rememberCheckbox = document.getElementById('rememberGeminiKey');
+}
+
+function loadStoredState() {
+    state.recentUploads = safeParseJson(readFromLocalStorage(STORAGE_KEYS.recentUploads), []);
+    state.favorites = new Set(
+        safeParseJson(readFromLocalStorage(STORAGE_KEYS.favorites), []).filter(Boolean)
+    );
+    const srsRaw = safeParseJson(readFromLocalStorage(STORAGE_KEYS.srs), null);
+    if (srsRaw && typeof srsRaw === 'object' && srsRaw.words) {
+        state.srs = srsRaw;
     }
 }
 
-function setStatusFlag(text, state) {
-    const flag = document.getElementById('uploadStatusFlag');
-    if (!flag) return;
-    flag.textContent = text;
-    flag.classList.remove('loading', 'success', 'error');
-    if (state) {
-        flag.classList.add(state);
+function bindGlobalEvents() {
+    if (elements.tabNav) {
+        elements.tabNav.addEventListener('click', (event) => {
+            const button = event.target.closest('button[data-route]');
+            if (!button) return;
+            setRoute(button.dataset.route);
+        });
     }
+
+    if (elements.dropZone) {
+        ['dragenter', 'dragover'].forEach((type) => {
+            elements.dropZone.addEventListener(type, (event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                elements.dropZone.classList.add('drag-over');
+            });
+        });
+        ['dragleave', 'dragend'].forEach((type) => {
+            elements.dropZone.addEventListener(type, () => {
+                elements.dropZone.classList.remove('drag-over');
+            });
+        });
+        elements.dropZone.addEventListener('drop', (event) => {
+            event.preventDefault();
+            elements.dropZone.classList.remove('drag-over');
+            if (event.dataTransfer && event.dataTransfer.files) {
+                handleFiles(Array.from(event.dataTransfer.files));
+            }
+        });
+        elements.dropZone.addEventListener('keydown', (event) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                if (elements.fileInput) elements.fileInput.click();
+            }
+        });
+    }
+
+    if (elements.pickFilesBtn && elements.fileInput) {
+        elements.pickFilesBtn.addEventListener('click', () => {
+            elements.fileInput.click();
+        });
+        elements.fileInput.addEventListener('change', () => {
+            const files = Array.from(elements.fileInput.files || []);
+            if (files.length) {
+                handleFiles(files);
+                elements.fileInput.value = '';
+            }
+        });
+    }
+
+    if (elements.wordList) {
+        elements.wordList.addEventListener('pointerover', (event) => {
+            const card = event.target.closest('.word-card');
+            if (!card) return;
+            setHoverWord(card.dataset.wordCard || null);
+        });
+        elements.wordList.addEventListener('pointerout', (event) => {
+            const card = event.target.closest('.word-card');
+            if (!card) {
+                setHoverWord(null);
+                return;
+            }
+            if (!card.contains(event.relatedTarget)) {
+                setHoverWord(null);
+            }
+        });
+        elements.wordList.addEventListener('click', (event) => {
+            const favButton = event.target.closest('.favorite-toggle');
+            if (favButton) {
+                event.stopPropagation();
+                toggleFavorite(favButton.dataset.wordFav || '');
+                return;
+            }
+            const card = event.target.closest('.word-card');
+            if (card) {
+                setActiveWord(card.dataset.wordCard || null, true);
+            }
+        });
+    }
+
+    if (elements.bboxLayer) {
+        elements.bboxLayer.addEventListener('pointerover', (event) => {
+            const box = event.target.closest('.bbox-box');
+            if (!box) return;
+            setHoverWord(box.dataset.wordBox || null);
+        });
+        elements.bboxLayer.addEventListener('pointerout', (event) => {
+            const box = event.target.closest('.bbox-box');
+            if (!box || !box.contains(event.relatedTarget)) {
+                setHoverWord(null);
+            }
+        });
+        elements.bboxLayer.addEventListener('click', (event) => {
+            const box = event.target.closest('.bbox-box');
+            if (!box) return;
+            const wordId = box.dataset.wordBox || null;
+            setActiveWord(wordId, true);
+            scrollWordIntoView(wordId);
+        });
+    }
+
+    if (elements.assetStrip) {
+        elements.assetStrip.addEventListener('click', (event) => {
+            const button = event.target.closest('[data-asset]');
+            if (!button) return;
+            selectAsset(button.dataset.asset);
+        });
+    }
+
+    if (elements.zoomControls) {
+        elements.zoomControls.addEventListener('click', (event) => {
+            const button = event.target.closest('button[data-zoom]');
+            if (!button) return;
+            adjustZoom(button.dataset.zoom);
+        });
+    }
+
+    if (elements.imageViewport) {
+        elements.imageViewport.addEventListener('pointerdown', handleViewportPointerDown);
+        window.addEventListener('pointermove', handleViewportPointerMove);
+        window.addEventListener('pointerup', handleViewportPointerUp);
+        elements.imageViewport.addEventListener('wheel', (event) => {
+            if (!state.selectedAssetId) return;
+            event.preventDefault();
+            const direction = event.deltaY > 0 ? 'out' : 'in';
+            adjustZoom(direction, { x: event.offsetX, y: event.offsetY });
+        }, { passive: false });
+    }
+
+    if (elements.readingQuiz) {
+        elements.readingQuiz.addEventListener('click', (event) => {
+            const option = event.target.closest('.reading-option');
+            if (!option) return;
+            const question = option.closest('.reading-question');
+            if (!question) return;
+            const questionId = question.dataset.questionId;
+            const value = option.dataset.questionOption || option.textContent || '';
+            handleReadingSelection(questionId, value.trim());
+        });
+    }
+
+    if (elements.reviewList) {
+        elements.reviewList.addEventListener('click', (event) => {
+            const button = event.target.closest('.review-btn');
+            if (!button) return;
+            const wordId = button.dataset.reviewWord;
+            if (!wordId) return;
+            const action = button.dataset.reviewAction;
+            handleReviewAction(wordId, action === 'pass');
+        });
+    }
+
+    window.addEventListener('hashchange', restoreRouteFromHash);
 }
 
-function toggleProgress(visible) {
-    const wrapper = document.getElementById('uploadProgressWrapper');
-    if (!wrapper) return;
-    if (visible) {
-        if (progressHideTimer) {
-            clearTimeout(progressHideTimer);
-            progressHideTimer = null;
-        }
-        wrapper.style.display = 'flex';
+function restoreRouteFromHash() {
+    const hash = window.location.hash.replace('#', '');
+    if (ROUTES.includes(hash)) {
+        state.route = hash;
+    } else if (state.session) {
+        state.route = 'study';
     } else {
-        wrapper.style.display = 'none';
-        updateUploadProgress(0);
-        if (progressHideTimer) {
-            clearTimeout(progressHideTimer);
-            progressHideTimer = null;
-        }
+        state.route = 'home';
+    }
+    renderRoute();
+}
+
+function setRoute(route) {
+    if (!ROUTES.includes(route)) return;
+    if (state.route === route) return;
+    state.route = route;
+    window.location.hash = route;
+    renderRoute();
+}
+
+function renderAll() {
+    renderRoute();
+    renderHome();
+    renderStudy();
+    renderReview();
+}
+
+function renderRoute() {
+    elements.viewSections.forEach((section) => {
+        const isActive = section.dataset.view === state.route;
+        section.classList.toggle('view-active', isActive);
+        section.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+    });
+    if (elements.tabNav) {
+        const buttons = elements.tabNav.querySelectorAll('button[data-route]');
+        buttons.forEach((button) => {
+            const active = button.dataset.route === state.route;
+            button.classList.toggle('is-active', active);
+            button.setAttribute('aria-selected', active ? 'true' : 'false');
+        });
     }
 }
 
-function updateUploadProgress(value) {
-    const fill = document.getElementById('uploadProgressFill');
-    const text = document.getElementById('uploadProgressText');
-    if (!fill || !text) return;
-    if (typeof value !== 'number' || Number.isNaN(value)) {
-        fill.style.width = '100%';
-        text.textContent = '···';
+function renderHome() {
+    if (!elements.uploadBadge) return;
+    if (state.uploading) {
+        elements.uploadBadge.textContent = '上传中';
+        elements.uploadBadge.classList.add('loading');
+    } else if (state.sessionId) {
+        elements.uploadBadge.textContent = '已生成';
+        elements.uploadBadge.classList.remove('loading');
+    } else {
+        elements.uploadBadge.textContent = '待开始';
+        elements.uploadBadge.classList.remove('loading');
+    }
+
+    if (elements.progressContainer) {
+        elements.progressContainer.classList.toggle('active', state.uploading);
+        if (state.uploading) {
+            if (typeof state.uploadProgress === 'number' && !state.uploadIndeterminate) {
+                const percentage = Math.max(0, Math.min(100, Math.round(state.uploadProgress * 100)));
+                elements.progressFill.style.width = `${percentage}%`;
+                elements.progressText.textContent = `${percentage}%`;
+            } else {
+                elements.progressFill.style.width = '100%';
+                elements.progressText.textContent = '···';
+            }
+        } else {
+            elements.progressFill.style.width = '0%';
+            elements.progressText.textContent = '0%';
+        }
+    }
+
+    if (elements.uploadError) {
+        elements.uploadError.textContent = state.uploadError || '';
+    }
+
+    renderRecentUploads();
+}
+
+function renderRecentUploads() {
+    if (!elements.recentGrid) return;
+    if (!Array.isArray(state.recentUploads) || state.recentUploads.length === 0) {
+        elements.recentGrid.innerHTML = buildRecentSkeleton();
+        if (elements.recentCount) {
+            elements.recentCount.textContent = '0';
+        }
         return;
     }
-    const percentage = Math.max(0, Math.min(100, Math.round(value * 100)));
-    fill.style.width = `${percentage}%`;
-    text.textContent = `${percentage}%`;
+    const items = state.recentUploads.slice(0, 10);
+    elements.recentGrid.innerHTML = items
+        .map((item) => {
+            const metaParts = [];
+            if (item.width && item.height) {
+                metaParts.push(`${item.width}×${item.height}`);
+            }
+            if (item.words) {
+                metaParts.push(`${item.words} 词`);
+            }
+            metaParts.push(formatRelativeTime(item.uploadedAt));
+            const preview = item.thumbnail
+                ? `<img src="${item.thumbnail}" alt="${escapeHtml(item.name || '学习图片')} 缩略图">`
+                : '<div class="skeleton-block skeleton-thumb"></div>';
+            return `
+                <div class="recent-card">
+                    ${preview}
+                    <div class="recent-meta">${escapeHtml(item.name || '未命名')}</div>
+                    <div class="recent-meta">${metaParts.map(escapeHtml).join(' · ')}</div>
+                </div>
+            `;
+        })
+        .join('');
+    if (elements.recentCount) {
+        elements.recentCount.textContent = `${items.length}`;
+    }
 }
 
-function showUploadFeedback(message, type = 'info') {
-    const container = document.getElementById('uploadFeedback');
-    if (!container) return;
-    container.textContent = message || '';
-    container.classList.remove('error', 'success');
-    if (type === 'error') {
-        container.classList.add('error');
-    } else if (type === 'success') {
-        container.classList.add('success');
+function renderStudy() {
+    if (!elements.assetMeta) return;
+    if (!state.session || !state.assets.length) {
+        elements.assetMeta.textContent = '无图像';
+        elements.assetStrip.innerHTML = '';
+        elements.imagePlaceholder.style.display = 'flex';
+        elements.studyImage.hidden = true;
+        elements.bboxLayer.innerHTML = '';
+        elements.wordCountBadge.textContent = '0';
+        elements.wordList.innerHTML = buildWordSkeleton();
+        elements.readingStatus.textContent = '未生成';
+        elements.readingQuiz.innerHTML = buildReadingSkeleton();
+        return;
     }
+
+    const selectedAsset = getSelectedAsset();
+    elements.assetMeta.textContent = selectedAsset
+        ? `${Math.round(selectedAsset.width)}×${Math.round(selectedAsset.height)}`
+        : `${state.assets.length} 张图像`;
+
+    elements.assetStrip.innerHTML = state.assets
+        .map((asset) => `
+            <button type="button" class="asset-thumb ${asset.id === state.selectedAssetId ? 'is-active' : ''}" data-asset="${asset.id}">
+                ${asset.thumbnail ? `<img src="${asset.thumbnail}" alt="${escapeHtml(asset.name || '图片')} 缩略图">` : '<div class="skeleton-block skeleton-thumb"></div>'}
+            </button>
+        `)
+        .join('');
+
+    if (selectedAsset) {
+        elements.imageStage.style.width = `${selectedAsset.width}px`;
+        elements.imageStage.style.height = `${selectedAsset.height}px`;
+        elements.studyImage.src = selectedAsset.url;
+        elements.studyImage.hidden = false;
+        elements.imagePlaceholder.style.display = 'none';
+        renderBoundingBoxes(selectedAsset);
+        applyViewerTransform();
+    } else {
+        elements.studyImage.hidden = true;
+        elements.imagePlaceholder.style.display = 'flex';
+        elements.bboxLayer.innerHTML = '';
+        elements.imageStage.style.width = '0px';
+        elements.imageStage.style.height = '0px';
+    }
+
+    elements.wordCountBadge.textContent = `${state.wordCards.length}`;
+    if (state.wordCards.length === 0) {
+        elements.wordList.innerHTML = buildWordSkeleton();
+    } else {
+        elements.wordList.innerHTML = state.wordCards
+            .map((card) => renderWordCard(card, state.favorites.has(card.id)))
+            .join('');
+    }
+    updateHighlights();
+
+    if (!state.readingQuestions.length) {
+        elements.readingStatus.textContent = '未生成';
+        elements.readingQuiz.innerHTML = buildReadingSkeleton();
+    } else {
+        const answered = Object.keys(state.readingResults).length;
+        elements.readingStatus.textContent = `已生成 ${answered}/${state.readingQuestions.length}`;
+        elements.readingQuiz.innerHTML = state.readingQuestions
+            .map((question, index) => renderReadingQuestion(question, index))
+            .join('');
+    }
+}
+
+function renderReview() {
+    if (!elements.reviewList) return;
+    const { dueToday, overflowCount } = computeDailyReviewList();
+    const totalWords = Object.keys(state.srs.words || {}).length;
+    const summaryText = `今日 ${dueToday.length} / 累积 ${totalWords}`;
+    elements.reviewSummary.textContent = summaryText;
+
+    if (!dueToday.length) {
+        elements.reviewList.innerHTML = `<div class="empty-placeholder">今日暂无待复习词汇，请完成阅读练习或继续打卡。</div>`;
+    } else {
+        elements.reviewList.innerHTML = dueToday.map(renderReviewItem).join('');
+    }
+
+    if (overflowCount > 0) {
+        elements.reviewOverflow.textContent = `已将额外的 ${overflowCount} 个词自动顺延至明日待复习。`;
+    } else {
+        elements.reviewOverflow.textContent = '';
+    }
+}
+
+function buildRecentSkeleton() {
+    return Array.from({ length: 6 })
+        .map(
+            () => `
+            <div class="recent-card">
+                <div class="skeleton-block skeleton-thumb"></div>
+                <div class="skeleton-block skeleton-line" style="width: 80%"></div>
+                <div class="skeleton-block skeleton-line" style="width: 60%"></div>
+            </div>
+        `
+        )
+        .join('');
+}
+
+function buildWordSkeleton() {
+    return Array.from({ length: 6 })
+        .map(
+            () => `
+            <div class="word-card">
+                <div class="skeleton-block skeleton-line" style="width: 40%; height: 18px"></div>
+                <div class="skeleton-block skeleton-line" style="width: 60%"></div>
+                <div class="skeleton-block skeleton-line" style="width: 90%"></div>
+                <div class="skeleton-block skeleton-line" style="width: 75%"></div>
+            </div>
+        `
+        )
+        .join('');
+}
+
+function buildReadingSkeleton() {
+    return Array.from({ length: 3 })
+        .map(
+            () => `
+            <div class="reading-question">
+                <div class="skeleton-block skeleton-line" style="width: 60%; height: 18px"></div>
+                <div class="skeleton-block skeleton-line" style="width: 100%"></div>
+                <div class="skeleton-block skeleton-line" style="width: 90%"></div>
+            </div>
+        `
+        )
+        .join('');
+}
+
+function renderWordCard(card, isFavorite) {
+    const topics = (card.topics || []).slice(0, 3).map((topic) => `<span class="topic-chip">${escapeHtml(topic)}</span>`).join('');
+    return `
+        <article class="word-card ${state.hoverWordId === card.id ? 'is-highlighted' : ''} ${state.activeWordId === card.id ? 'is-active' : ''}" data-word-card="${card.id}">
+            <header>
+                <div>
+                    <h3>${escapeHtml(card.lemma)}</h3>
+                    <div class="word-meta">${escapeHtml(card.pos)} · <span class="phonetic">${escapeHtml(card.phonetic)}</span></div>
+                </div>
+                <button type="button" class="favorite-toggle" aria-pressed="${isFavorite ? 'true' : 'false'}" data-word-fav="${card.id}" title="收藏">
+                    ${isFavorite ? '★' : '☆'}
+                </button>
+            </header>
+            <p class="word-definition">${escapeHtml(card.definition)}</p>
+            <p class="word-example">${escapeHtml(card.example)}</p>
+            <div class="word-topics">${topics}</div>
+        </article>
+    `;
+}
+
+function renderReadingQuestion(question, index) {
+    const result = state.readingResults[question.id];
+    const statusClass = result ? (result.status === 'correct' ? 'correct' : 'incorrect') : '';
+    const explanation = result ? result.explanation || '' : '';
+    const selectedValue = result ? result.selected : '';
+    const optionsHtml = question.options
+        .map((option) => {
+            const normalisedOption = option.trim();
+            const resultClass = !result
+                ? ''
+                : normaliseAnswer(normalisedOption) === normaliseAnswer(selectedValue)
+                ? `is-selected ${result.status === 'correct' ? 'is-correct' : 'is-incorrect'}`
+                : '';
+            return `
+                <button type="button" class="reading-option ${resultClass}" data-question-option="${escapeAttribute(normalisedOption)}" ${result ? 'disabled' : ''}>
+                    ${escapeHtml(option)}
+                </button>
+            `;
+        })
+        .join('');
+    return `
+        <div class="reading-question" data-question-id="${question.id}">
+            <div class="question-header">
+                <span class="question-index">${index + 1}</span>
+                <p class="question-prompt">${escapeHtml(question.prompt)}</p>
+            </div>
+            <div class="option-list">${optionsHtml}</div>
+            <p class="question-hint">提示：${escapeHtml(question.hint || '仔细阅读情境段落')}</p>
+            <p class="question-result ${statusClass}">${escapeHtml(explanation)}</p>
+        </div>
+    `;
+}
+
+function renderBoundingBoxes(asset) {
+    if (!asset || !elements.bboxLayer) return;
+    const boxesHtml = (asset.boxes || [])
+        .map((box) => {
+            const styles = `left:${box.x}px;top:${box.y}px;width:${box.width}px;height:${box.height}px;`;
+            const highlightClass = [state.hoverWordId, state.activeWordId].includes(box.wordId) ? 'is-highlighted' : '';
+            const activeClass = state.activeWordId === box.wordId ? 'is-active' : '';
+            return `<div class="bbox-box ${highlightClass} ${activeClass}" data-word-box="${box.wordId}" data-label="${escapeAttribute(box.label || '')}" style="${styles}"></div>`;
+        })
+        .join('');
+    elements.bboxLayer.innerHTML = boxesHtml;
+}
+
+function renderReviewItem(entry) {
+    const display = entry.display || {};
+    const topics = Array.isArray(display.topics)
+        ? display.topics.slice(0, 3).map((topic) => `<span class="topic-chip">${escapeHtml(topic)}</span>`).join('')
+        : '';
+    const masteryLabel = `记忆等级 Lv.${entry.mastery ?? 0}`;
+    return `
+        <div class="review-item" data-review-word="${entry.id}">
+            <div class="review-word">
+                <h3>${escapeHtml(entry.lemma || entry.id)}</h3>
+                <p>${escapeHtml(display.pos || '—')} · ${escapeHtml(display.phonetic || '—')}</p>
+            </div>
+            <div>
+                <div class="review-definition">${escapeHtml(display.definition || '情境词汇')}</div>
+                <div class="word-topics">${topics}</div>
+                <div class="review-meta">${masteryLabel} · 下次复习：${formatDate(entry.nextReview)}</div>
+            </div>
+            <div class="review-actions">
+                <button type="button" class="review-btn" data-review-word="${entry.id}" data-review-action="again">仍需复习</button>
+                <button type="button" class="review-btn primary" data-review-word="${entry.id}" data-review-action="pass">我会了</button>
+            </div>
+        </div>
+    `;
+}
+
+function handleFiles(files) {
+    if (!files.length || state.uploading) {
+        return;
+    }
+    const errors = [];
+    const accepted = [];
+    files.slice(0, 3).forEach((file) => {
+        const validation = validateFile(file);
+        if (validation) {
+            errors.push(`${file.name}: ${validation}`);
+        } else {
+            accepted.push(file);
+        }
+    });
+    if (errors.length) {
+        state.uploadError = errors.join('；');
+        renderHome();
+    }
+    if (!accepted.length) {
+        return;
+    }
+    startUpload(accepted);
+}
+
+function validateFile(file) {
+    if (!file) return '无法读取文件';
+    if (!ACCEPTED_TYPES.has(file.type)) {
+        const name = file.name || '';
+        if (!/\.(jpe?g|png)$/i.test(name)) {
+            return '格式不支持，请上传 JPG 或 PNG 图片';
+        }
+    }
+    if (file.size > MAX_FILE_SIZE) {
+        return '文件过大，请控制在 10MB 以内';
+    }
+    return '';
+}
+
+async function startUpload(files) {
+    state.uploading = true;
+    state.uploadError = '';
+    state.uploadProgress = 0;
+    state.uploadIndeterminate = false;
+    state.studySkeletonActive = true;
+    state.lastSkeletonAt = Date.now();
+    renderHome();
+    renderStudy();
+
+    try {
+        const assets = await Promise.all(files.map(createAssetFromFile));
+        const formData = new FormData();
+        files.forEach((file) => formData.append('files', file));
+        const apiKey = getActiveGeminiApiKey();
+        if (apiKey) {
+            formData.append('gemini_api_key', apiKey);
+        }
+
+        if (window.usageTracker) {
+            usageTracker.track({ feature: 'ielts-study-system', action: 'upload-start' });
+        }
+
+        const payload = await uploadWithProgress('/api/ielts/upload-batch', formData, (progress) => {
+            if (progress == null) {
+                state.uploadIndeterminate = true;
+            } else {
+                state.uploadIndeterminate = false;
+                state.uploadProgress = progress;
+            }
+            renderHome();
+        });
+
+        processSessionPayload(payload, assets);
+
+        if (window.usageTracker) {
+            usageTracker.track({ feature: 'ielts-study-system', action: 'upload-success' });
+        }
+    } catch (error) {
+        const message = (error && error.message) || '生成学习素材失败，请稍后重试';
+        state.uploadError = message;
+        if (elements.uploadBadge) {
+            elements.uploadBadge.textContent = '上传失败';
+            elements.uploadBadge.classList.add('error');
+        }
+        if (window.usageTracker) {
+            usageTracker.track({ feature: 'ielts-study-system', action: 'upload-error', detail: message });
+        }
+    } finally {
+        state.uploading = false;
+        state.uploadIndeterminate = false;
+        state.uploadProgress = 0;
+        if (progressHideTimer) {
+            clearTimeout(progressHideTimer);
+        }
+        progressHideTimer = setTimeout(() => {
+            renderHome();
+            progressHideTimer = null;
+        }, 600);
+    }
+}
+
+function processSessionPayload(data, assets) {
+    if (!data || typeof data !== 'object') {
+        state.uploadError = '服务器未返回有效数据';
+        renderHome();
+        return;
+    }
+    state.sessionId = data.session_id || '';
+    state.session = {
+        words: data.words || {},
+        story: data.story || {},
+        reading: data.reading || {},
+        listening: data.listening || {},
+        conversation: data.conversation || {}
+    };
+    state.assets = assets.map((asset) => ({ ...asset, boxes: [] }));
+    state.selectedAssetId = state.assets[0] ? state.assets[0].id : null;
+    state.viewerTransforms = {};
+
+    state.wordCards = buildWordCards(state.session);
+    registerWordsForSrs(state.wordCards);
+    assignBoundingBoxes();
+    state.activeWordId = state.wordCards[0] ? state.wordCards[0].id : null;
+
+    state.readingQuestions = buildReadingQuestions(state.session.reading, state.wordCards);
+    state.readingResults = {};
+
+    appendRecentUploads(assets, state.session.words);
+    saveRecentUploads();
+    saveFavorites();
+    saveSrsProgress();
+
+    state.studySkeletonActive = false;
+    renderAll();
+    setRoute('study');
+}
+
+function assignBoundingBoxes() {
+    if (!state.assets.length || !state.wordCards.length) return;
+    const assetCount = state.assets.length;
+    const wordsPerAsset = Math.max(1, Math.ceil(state.wordCards.length / assetCount));
+    state.assets.forEach((asset) => {
+        asset.boxes = [];
+    });
+    state.wordCards.forEach((card, index) => {
+        const assetIndex = Math.min(state.assets.length - 1, Math.floor(index / wordsPerAsset));
+        const asset = state.assets[assetIndex];
+        const box = generateBoundingBox(asset, card, index);
+        asset.boxes.push(box);
+    });
+}
+
+function generateBoundingBox(asset, card, index) {
+    const width = asset.width || 800;
+    const height = asset.height || 600;
+    const hash = stringHash(`${card.id}-${asset.id}-${index}`);
+    const boxWidth = Math.max(80, Math.min(width * 0.45, 120 + (hash % 140)));
+    const boxHeight = Math.max(48, Math.min(height * 0.3, 60 + ((hash >> 3) % 100)));
+    const maxX = Math.max(0, width - boxWidth);
+    const maxY = Math.max(0, height - boxHeight);
+    const x = maxX ? (hash * 31) % maxX : 0;
+    const y = maxY ? (hash * 17) % maxY : 0;
+    return {
+        id: `${asset.id}-${card.id}`,
+        wordId: card.id,
+        label: card.lemma,
+        x,
+        y,
+        width: boxWidth,
+        height: boxHeight
+    };
+}
+
+function buildWordCards(session) {
+    const result = [];
+    const words = (session.words && session.words.items) || [];
+    const story = session.story || {};
+    const sentences = Array.isArray(story.sentences) ? story.sentences : [];
+    const paragraphs = Array.isArray(story.paragraphs) ? story.paragraphs : [];
+    const topics = buildStoryTopics(story);
+
+    words.forEach((word, index) => {
+        const normalised = (word || '').toLowerCase();
+        const detail = sentences.find((item) => (item.word || '').toLowerCase() === normalised) || {};
+        const lemma = capitalize(detail.word || word || '');
+        const pos = detail.pos || guessPartOfSpeech(word);
+        const phonetic = normalisePhonetic(detail.phonetic) || buildPseudoPhonetic(word);
+        const definitionSource = detail.hint || detail.rationale || paragraphs[index % (paragraphs.length || 1)] || story.overview || `关注 ${lemma} 在情境中的作用。`;
+        const example = detail.sentence || paragraphs[index % (paragraphs.length || 1)] || story.scenario || story.overview || '结合情境理解词义。';
+        result.push({
+            id: normalised,
+            lemma,
+            pos,
+            phonetic,
+            definition: truncateWords(definitionSource, 16),
+            example: truncateWords(example, 22),
+            topics,
+            focus: Array.isArray(detail.focus_words) ? detail.focus_words : []
+        });
+    });
+    return result;
+}
+
+function buildStoryTopics(story) {
+    const candidates = [story.setting, story.audience, story.title, story.scenario, story.overview];
+    const topics = [];
+    candidates.forEach((candidate) => {
+        if (!candidate) return;
+        String(candidate)
+            .split(/[、,，\/]/)
+            .map((item) => item.trim())
+            .filter(Boolean)
+            .forEach((item) => {
+                if (!topics.includes(item) && topics.length < 5) {
+                    topics.push(item);
+                }
+            });
+    });
+    if (!topics.length) {
+        topics.push('IELTS');
+    }
+    return topics;
+}
+
+function buildReadingQuestions(reading, wordCards) {
+    const questions = Array.isArray(reading?.questions) ? reading.questions.slice(0, 3) : [];
+    const fallbackWords = wordCards.map((card) => card.lemma);
+    return questions.map((question, index) => {
+        const id = question.id || `R${index + 1}`;
+        const focusWords = Array.isArray(question.focus_words)
+            ? question.focus_words.map((item) => String(item).trim()).filter(Boolean)
+            : [];
+        const answerKey = (focusWords[0] || question.answer || '').trim();
+        const hint = question.hint || (question.rationale ? truncateWords(question.rationale, 18) : '留意故事中的关键词。');
+        const prompt = question.prompt || '根据情境选择最合适的单词。';
+        const options = buildQuestionOptions(question, fallbackWords, answerKey);
+        return {
+            id,
+            prompt,
+            hint,
+            options,
+            focusWords,
+            answerKey
+        };
+    });
+}
+
+function buildQuestionOptions(question, fallbackWords, answerKey) {
+    const options = new Set();
+    const questionOptions = question.options || question.choices || [];
+    questionOptions.forEach((option) => {
+        if (typeof option === 'string' && option.trim()) {
+            options.add(option.trim());
+        }
+    });
+    (question.focus_words || []).forEach((option) => {
+        if (typeof option === 'string' && option.trim()) {
+            options.add(option.trim());
+        }
+    });
+    if (answerKey) {
+        options.add(answerKey.trim());
+    }
+    const pool = fallbackWords.filter((word) => word && !options.has(word));
+    while (options.size < 3 && pool.length) {
+        const index = Math.floor(Math.random() * pool.length);
+        options.add(pool.splice(index, 1)[0]);
+    }
+    while (options.size < 3) {
+        options.add(`选项 ${options.size + 1}`);
+    }
+    return Array.from(options).slice(0, 3);
+}
+
+async function createAssetFromFile(file) {
+    const dataUrl = await readFileAsDataUrl(file);
+    const imageMeta = await loadImageMeta(dataUrl);
+    const thumbnail = await createThumbnail(dataUrl, 320, 240);
+    return {
+        id: `asset-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`,
+        name: file.name,
+        size: file.size,
+        type: file.type,
+        url: dataUrl,
+        thumbnail,
+        width: imageMeta.width,
+        height: imageMeta.height,
+        uploadedAt: Date.now(),
+        boxes: []
+    };
+}
+
+function readFileAsDataUrl(file) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result);
+        reader.onerror = () => reject(new Error('无法读取文件内容'));
+        reader.readAsDataURL(file);
+    });
+}
+
+function loadImageMeta(dataUrl) {
+    return new Promise((resolve) => {
+        const image = new Image();
+        image.onload = () => {
+            resolve({ width: image.naturalWidth || 0, height: image.naturalHeight || 0 });
+        };
+        image.onerror = () => resolve({ width: 0, height: 0 });
+        image.src = dataUrl;
+    });
+}
+
+async function createThumbnail(dataUrl, targetWidth, targetHeight) {
+    try {
+        const image = await loadImageElement(dataUrl);
+        const width = image.naturalWidth || targetWidth;
+        const height = image.naturalHeight || targetHeight;
+        const ratio = Math.min(targetWidth / width, targetHeight / height, 1);
+        const canvas = document.createElement('canvas');
+        canvas.width = Math.round(width * ratio);
+        canvas.height = Math.round(height * ratio);
+        const ctx = canvas.getContext('2d');
+        ctx.drawImage(image, 0, 0, canvas.width, canvas.height);
+        return canvas.toDataURL('image/jpeg', 0.7);
+    } catch (error) {
+        console.warn('Failed to create thumbnail', error);
+        return '';
+    }
+}
+
+function loadImageElement(dataUrl) {
+    return new Promise((resolve, reject) => {
+        const image = new Image();
+        image.onload = () => resolve(image);
+        image.onerror = (err) => reject(err);
+        image.src = dataUrl;
+    });
 }
 
 function uploadWithProgress(url, formData, onProgress) {
@@ -207,314 +954,569 @@ function uploadWithProgress(url, formData, onProgress) {
         };
         xhr.onload = () => {
             if (xhr.status >= 200 && xhr.status < 300) {
-                if (xhr.response && typeof xhr.response === 'object') {
-                    resolve(xhr.response);
-                } else if (xhr.responseText) {
-                    try {
-                        resolve(JSON.parse(xhr.responseText));
-                    } catch (err) {
-                        resolve({});
-                    }
-                } else {
-                    resolve({});
-                }
+                resolve(xhr.response || {});
             } else {
-                const message = parseXHRError(xhr) || '生成学习素材失败';
-                reject(new Error(message));
+                reject(new Error(parseXHRError(xhr) || '上传失败'));
             }
         };
-        xhr.onerror = () => {
-            reject(new Error('网络异常，请稍后重试'));
-        };
+        xhr.onerror = () => reject(new Error('网络异常，请稍后重试'));
         xhr.send(formData);
     });
-}
-
-function normaliseErrorDetail(value) {
-    if (value == null) {
-        return '';
-    }
-    if (typeof value === 'string') {
-        return value;
-    }
-    if (Array.isArray(value)) {
-        return value
-            .map((item) => normaliseErrorDetail(item))
-            .filter(Boolean)
-            .join('；');
-    }
-    if (typeof value === 'object') {
-        const preferredKeys = ['detail', 'message', 'msg', 'error'];
-        for (const key of preferredKeys) {
-            if (key in value) {
-                const result = normaliseErrorDetail(value[key]);
-                if (result) {
-                    return result;
-                }
-            }
-        }
-        const parts = Object.values(value)
-            .map((item) => normaliseErrorDetail(item))
-            .filter(Boolean);
-        if (parts.length > 0) {
-            return parts.join('；');
-        }
-        try {
-            return JSON.stringify(value);
-        } catch (err) {
-            return String(value);
-        }
-    }
-    return String(value);
 }
 
 function parseXHRError(xhr) {
     try {
         if (xhr.response && typeof xhr.response === 'object') {
-            const message = normaliseErrorDetail(xhr.response.detail || xhr.response.message || xhr.response);
-            if (message) {
-                return message;
-            }
+            return normaliseErrorDetail(xhr.response.detail || xhr.response.message || xhr.response);
         }
         if (xhr.responseText) {
-            try {
-                const parsed = JSON.parse(xhr.responseText);
-                const message = normaliseErrorDetail(parsed.detail || parsed.message || parsed);
-                if (message) {
-                    return message;
-                }
-            } catch (err) {
-                return xhr.responseText;
-            }
+            const parsed = JSON.parse(xhr.responseText);
+            return normaliseErrorDetail(parsed.detail || parsed.message || parsed);
         }
-    } catch (err) {
-        return xhr.responseText || '';
+    } catch (error) {
+        return xhr.responseText || '请求失败';
     }
     return '';
 }
 
-function parseManualWords(text) {
-    return text
-        .split(/[\n,;，\uFF0C]+/)
-        .map((item) => item.trim())
-        .filter(Boolean);
+function normaliseErrorDetail(value) {
+    if (!value) return '';
+    if (typeof value === 'string') return value;
+    if (Array.isArray(value)) {
+        return value.map((item) => normaliseErrorDetail(item)).filter(Boolean).join('；');
+    }
+    if (typeof value === 'object') {
+        const keys = ['detail', 'message', 'error'];
+        for (const key of keys) {
+            if (key in value) {
+                const result = normaliseErrorDetail(value[key]);
+                if (result) return result;
+            }
+        }
+        return Object.values(value)
+            .map((item) => normaliseErrorDetail(item))
+            .filter(Boolean)
+            .join('；');
+    }
+    return String(value);
 }
 
-async function handleUploadSubmit(event) {
-    event.preventDefault();
-    const button = document.getElementById('uploadBtn');
-    const summaryBox = document.getElementById('uploadSummary');
-    const scenarioBox = document.getElementById('scenarioContent');
+function setHoverWord(wordId) {
+    if (state.hoverWordId === wordId) return;
+    state.hoverWordId = wordId;
+    updateHighlights();
+}
 
-    button.disabled = true;
-    button.textContent = '生成中...';
-    if (summaryBox) {
-        summaryBox.style.display = 'block';
-        summaryBox.innerHTML = '<p>正在解析图片并提取词汇，请稍候...</p>';
+function setActiveWord(wordId, pin = false) {
+    if (wordId && pin) {
+        state.activeWordId = wordId;
+    } else if (!pin) {
+        state.activeWordId = wordId;
     }
-    if (scenarioBox) {
-        scenarioBox.innerHTML = '<p class="placeholder">正在生成情景片段...</p>';
-    }
-    setStatusFlag('上传中', 'loading');
-    setStatus('scenarioStatus', '生成中', 'loading');
-    toggleProgress(true);
-    updateUploadProgress(0);
-    showUploadFeedback('正在上传文件并调用 Gemini 解析...', 'info');
+    updateHighlights();
+}
 
-    try {
-        const formData = new FormData();
-        const fileInput = document.getElementById('wordImages');
-        const manualInput = document.getElementById('manualWords');
-        const scenarioInput = document.getElementById('scenarioHint');
-        const apiInput = document.getElementById('geminiApiKey');
-        const rememberCheckbox = document.getElementById('rememberGeminiKey');
-        const geminiApiKey = apiInput ? apiInput.value.trim() : '';
-        const rememberGeminiKey = rememberCheckbox ? rememberCheckbox.checked : false;
-
-        if (fileInput && fileInput.files.length > 0) {
-            Array.from(fileInput.files).forEach((file) => formData.append('files', file));
-        }
-        if (manualInput) {
-            const manualWords = parseManualWords(manualInput.value.trim());
-            if (manualWords.length > 0) {
-                formData.append('manual_words', JSON.stringify(manualWords));
-            }
-        }
-        if (scenarioInput && scenarioInput.value.trim()) {
-            formData.append('scenario_hint', scenarioInput.value.trim());
-        }
-        if (geminiApiKey) {
-            formData.append('gemini_api_key', geminiApiKey);
-        }
-
-        if (rememberCheckbox) {
-            if (rememberGeminiKey) {
-                persistRememberPreference(true);
-                persistGeminiKey(geminiApiKey);
-            } else {
-                persistRememberPreference(false);
-            }
-        }
-
-        if (window.usageTracker) {
-            usageTracker.track({ feature: 'ielts-study-system', action: 'upload-start' });
-        }
-
-        const data = await uploadWithProgress('/api/ielts/upload-batch', formData, (progress) => {
-            if (progress === null) {
-                showUploadFeedback('正在上传文件...', 'info');
-                updateUploadProgress(NaN);
-            } else {
-                updateUploadProgress(progress);
-                if (progress >= 1) {
-                    showUploadFeedback('上传完成，正在生成情景片段...', 'info');
-                }
+function updateHighlights() {
+    if (elements.wordList) {
+        const cards = elements.wordList.querySelectorAll('.word-card');
+        cards.forEach((card) => {
+            const wordId = card.dataset.wordCard;
+            card.classList.toggle('is-highlighted', wordId === state.hoverWordId);
+            card.classList.toggle('is-active', wordId === state.activeWordId);
+            const fav = card.querySelector('.favorite-toggle');
+            if (fav) {
+                fav.setAttribute('aria-pressed', state.favorites.has(wordId) ? 'true' : 'false');
+                fav.textContent = state.favorites.has(wordId) ? '★' : '☆';
             }
         });
-
-        if (window.usageTracker) {
-            usageTracker.track({ feature: 'ielts-study-system', action: 'upload-success' });
-        }
-
-        renderSession(data || {});
-    } catch (error) {
-        const message = error && error.message ? error.message : '生成学习素材失败';
-        setStatus('scenarioStatus', '等待生成', 'waiting');
-        setStatusFlag('上传失败', 'error');
-        showUploadFeedback(message, 'error');
-        toggleProgress(false);
-        if (summaryBox) {
-            summaryBox.innerHTML = `<p class="error">${escapeHtml(message)}</p>`;
-        }
-        if (scenarioBox) {
-            scenarioBox.innerHTML = '<p class="placeholder">请重新上传文件以生成情景片段。</p>';
-        }
-        if (window.usageTracker) {
-            usageTracker.track({ feature: 'ielts-study-system', action: 'upload-error', detail: message });
-        }
-    } finally {
-        button.disabled = false;
-        button.textContent = '生成情景素材';
+    }
+    if (elements.bboxLayer) {
+        const boxes = elements.bboxLayer.querySelectorAll('.bbox-box');
+        boxes.forEach((box) => {
+            const wordId = box.dataset.wordBox;
+            box.classList.toggle('is-highlighted', wordId === state.hoverWordId || wordId === state.activeWordId);
+            box.classList.toggle('is-active', wordId === state.activeWordId);
+        });
     }
 }
 
-function renderSession(data) {
-    currentSessionId = data.session_id || '';
-    sessionPayload = data;
-    setStatusFlag('上传成功', 'success');
-    updateUploadProgress(1);
-    showUploadFeedback('上传成功，情景片段已生成 ✅', 'success');
-    if (progressHideTimer) {
-        clearTimeout(progressHideTimer);
+function scrollWordIntoView(wordId) {
+    if (!wordId || !elements.wordList) return;
+    const target = elements.wordList.querySelector(`.word-card[data-word-card="${wordId}"]`);
+    if (target && typeof target.scrollIntoView === 'function') {
+        target.scrollIntoView({ block: 'center', behavior: 'smooth' });
     }
-    progressHideTimer = setTimeout(() => {
-        toggleProgress(false);
-        progressHideTimer = null;
-    }, 600);
-
-    renderUploadSummary(data);
-    renderScenarioContent(data.story, data.words);
 }
 
-function renderUploadSummary(data) {
-    const container = document.getElementById('uploadSummary');
-    if (!container) return;
-
-    const words = data.words || {};
-    const items = Array.isArray(words.items) ? words.items : [];
-    const duplicates = Array.isArray(words.duplicates) ? words.duplicates : [];
-    const rejected = Array.isArray(words.rejected) ? words.rejected : [];
-    const notes = Array.isArray(words.extraction_notes) ? words.extraction_notes : [];
-
-    const duplicatesHtml = duplicates.length
-        ? `<div class="meta-note">重复词已去重：${duplicates.map(escapeHtml).join(', ')}</div>`
-        : '';
-    const rejectedHtml = rejected.length
-        ? `<div class="meta-note">忽略的内容：${rejected.map(escapeHtml).join(', ')}</div>`
-        : '';
-    const notesHtml = notes.length
-        ? `<ul class="meta-note">${notes.map((item) => `<li>${escapeHtml(item)}</li>`).join('')}</ul>`
-        : '';
-    const wordChips = items.length
-        ? items.map((word) => `<span class="word-chip">${escapeHtml(word)}</span>`).join('')
-        : '<span class="placeholder">未识别到有效词汇。</span>';
-
-    container.style.display = 'block';
-    container.innerHTML = `
-        <div class="session-chip">会话 ID：${currentSessionId ? escapeHtml(currentSessionId.slice(0, 8)) : '暂无'}</div>
-        <p>共识别 <strong>${words.total || items.length}</strong> 个有效词汇，全部用于生成下方情景片段。</p>
-        ${duplicatesHtml}
-        ${rejectedHtml}
-        ${notesHtml}
-        <div class="word-grid">${wordChips}</div>
-    `;
+function selectAsset(assetId) {
+    if (!assetId || state.selectedAssetId === assetId) return;
+    state.selectedAssetId = assetId;
+    if (!state.viewerTransforms[assetId]) {
+        state.viewerTransforms[assetId] = { scale: 1, translateX: 0, translateY: 0 };
+    }
+    renderStudy();
 }
 
-function renderScenarioContent(story, words) {
-    const container = document.getElementById('scenarioContent');
-    if (!container) return;
+function getSelectedAsset() {
+    if (!state.selectedAssetId) {
+        return state.assets[0] || null;
+    }
+    return state.assets.find((asset) => asset.id === state.selectedAssetId) || state.assets[0] || null;
+}
 
-    if (!story) {
-        container.innerHTML = '<p class="placeholder">未能生成情景片段，请重试或补充更多提示。</p>';
-        setStatus('scenarioStatus', '等待生成', 'waiting');
+function adjustZoom(action, center) {
+    const asset = getSelectedAsset();
+    if (!asset) return;
+    const transform = getCurrentTransform(asset.id);
+    const factor = action === 'in' ? 1.2 : action === 'out' ? 1 / 1.2 : 1;
+    if (action === 'reset') {
+        state.viewerTransforms[asset.id] = { scale: 1, translateX: 0, translateY: 0 };
+        applyViewerTransform();
         return;
     }
+    let newScale = transform.scale * factor;
+    newScale = Math.max(0.5, Math.min(3, newScale));
+    const viewportRect = elements.imageViewport.getBoundingClientRect();
+    const originX = center ? center.x : viewportRect.width / 2;
+    const originY = center ? center.y : viewportRect.height / 2;
+    const translateX = transform.translateX + (originX - viewportRect.width / 2) * (1 - factor);
+    const translateY = transform.translateY + (originY - viewportRect.height / 2) * (1 - factor);
+    state.viewerTransforms[asset.id] = {
+        scale: newScale,
+        translateX,
+        translateY
+    };
+    applyViewerTransform();
+}
 
-    const title = story.title ? escapeHtml(story.title) : '情景片段';
-    const scenario = story.scenario ? `<p class="story-overview">${escapeHtml(story.scenario)}</p>` : '';
-    const overview = story.overview ? `<p class="story-overview">${escapeHtml(story.overview)}</p>` : '';
-    const paragraphs = Array.isArray(story.paragraphs)
-        ? story.paragraphs.map((paragraph) => `<p>${escapeHtml(paragraph)}</p>`).join('')
-        : '';
-    const closing = story.closing ? `<p class="story-overview">${escapeHtml(story.closing)}</p>` : '';
+function getCurrentTransform(assetId) {
+    if (!state.viewerTransforms[assetId]) {
+        state.viewerTransforms[assetId] = { scale: 1, translateX: 0, translateY: 0 };
+    }
+    return state.viewerTransforms[assetId];
+}
 
-    const segments = Array.isArray(story.sentences) ? story.sentences : [];
-    const segmentList = segments.length
-        ? `<div class="scenario-list-wrapper">
-                <h3>逐词情景提示</h3>
-                <ul class="segment-list">
-                    ${segments
-                        .map(
-                            (item, index) => `
-                                <li class="segment-item">
-                                    <strong>${index + 1}. ${escapeHtml(item.word || '')}</strong>
-                                    <p>${escapeHtml(item.hint || '')}</p>
-                                </li>
-                            `,
-                        )
-                        .join('')}
-                </ul>
-            </div>`
-        : '';
+function applyViewerTransform() {
+    const asset = getSelectedAsset();
+    if (!asset) return;
+    const transform = getCurrentTransform(asset.id);
+    elements.imageStage.style.setProperty('--scale', transform.scale);
+    elements.imageStage.style.setProperty('--translate-x', `${transform.translateX}px`);
+    elements.imageStage.style.setProperty('--translate-y', `${transform.translateY}px`);
+    renderBoundingBoxes(asset);
+    updateHighlights();
+}
 
-    const focusWordList = words && Array.isArray(words.items) ? words.items : [];
-    const focusHtml = focusWordList.length
-        ? `<div class="meta-note">本段故事聚焦词汇：${focusWordList.map(escapeHtml).join('、')}</div>`
-        : '';
+function handleViewportPointerDown(event) {
+    if (!state.selectedAssetId) return;
+    const asset = getSelectedAsset();
+    if (!asset) return;
+    dragState = {
+        assetId: asset.id,
+        startX: event.clientX,
+        startY: event.clientY,
+        baseX: getCurrentTransform(asset.id).translateX,
+        baseY: getCurrentTransform(asset.id).translateY,
+        moved: false
+    };
+    elements.imageViewport.setPointerCapture(event.pointerId);
+}
 
-    container.innerHTML = `
-        <div class="story-block">
-            <h3>${title}</h3>
-            ${scenario}
-            ${overview}
-            ${paragraphs}
-            ${closing}
-            ${focusHtml}
-        </div>
-        ${segmentList}
-    `;
+function handleViewportPointerMove(event) {
+    if (!dragState) return;
+    event.preventDefault();
+    const deltaX = event.clientX - dragState.startX;
+    const deltaY = event.clientY - dragState.startY;
+    if (Math.abs(deltaX) > 1 || Math.abs(deltaY) > 1) {
+        dragState.moved = true;
+    }
+    const transform = getCurrentTransform(dragState.assetId);
+    state.viewerTransforms[dragState.assetId] = {
+        ...transform,
+        translateX: dragState.baseX + deltaX,
+        translateY: dragState.baseY + deltaY
+    };
+    applyViewerTransform();
+}
 
-    setStatus('scenarioStatus', '已生成', 'ready');
+function handleViewportPointerUp(event) {
+    if (!dragState) return;
+    if (elements.imageViewport.hasPointerCapture(event.pointerId)) {
+        elements.imageViewport.releasePointerCapture(event.pointerId);
+    }
+    dragState = null;
+}
+
+function toggleFavorite(wordId) {
+    if (!wordId) return;
+    if (state.favorites.has(wordId)) {
+        state.favorites.delete(wordId);
+    } else {
+        state.favorites.add(wordId);
+    }
+    saveFavorites();
+    updateHighlights();
+}
+
+function appendRecentUploads(assets, wordsMeta) {
+    const wordCount = wordsMeta?.total || (wordsMeta?.items ? wordsMeta.items.length : 0) || 0;
+    const entries = assets.map((asset) => ({
+        id: asset.id,
+        name: asset.name,
+        uploadedAt: asset.uploadedAt,
+        thumbnail: asset.thumbnail,
+        width: Math.round(asset.width),
+        height: Math.round(asset.height),
+        words: wordCount
+    }));
+    state.recentUploads = [...entries, ...state.recentUploads].slice(0, 10);
+}
+
+function saveRecentUploads() {
+    writeToLocalStorage(STORAGE_KEYS.recentUploads, JSON.stringify(state.recentUploads));
+}
+
+function saveFavorites() {
+    writeToLocalStorage(STORAGE_KEYS.favorites, JSON.stringify(Array.from(state.favorites)));
+}
+
+function registerWordsForSrs(wordCards) {
+    if (!Array.isArray(wordCards)) return;
+    const now = Date.now();
+    state.srs.words = state.srs.words || {};
+    wordCards.forEach((card) => {
+        const existing = state.srs.words[card.id];
+        const display = {
+            pos: card.pos,
+            phonetic: card.phonetic,
+            definition: card.definition,
+            example: card.example,
+            topics: card.topics
+        };
+        if (existing) {
+            existing.lemma = card.lemma;
+            existing.display = display;
+        } else {
+            state.srs.words[card.id] = {
+                id: card.id,
+                lemma: card.lemma,
+                mastery: 0,
+                nextReview: now,
+                history: [],
+                display
+            };
+        }
+    });
+}
+
+function updateSrsEntry(wordId, success, source, context) {
+    if (!wordId) return;
+    state.srs.words = state.srs.words || {};
+    if (!state.srs.words[wordId]) {
+        state.srs.words[wordId] = {
+            id: wordId,
+            lemma: capitalize(wordId),
+            mastery: 0,
+            nextReview: Date.now(),
+            history: [],
+            display: { pos: '—', phonetic: '—', definition: '情境词汇', example: '', topics: [] }
+        };
+    }
+    const entry = state.srs.words[wordId];
+    entry.mastery = entry.mastery || 0;
+    if (success) {
+        entry.mastery = Math.min(5, entry.mastery + 1);
+    } else {
+        entry.mastery = Math.max(0, entry.mastery - 1);
+    }
+    const days = MASTERY_INTERVALS[entry.mastery] ?? 1;
+    entry.nextReview = Date.now() + days * 24 * 60 * 60 * 1000;
+    entry.history = entry.history || [];
+    entry.history.push({
+        timestamp: Date.now(),
+        success,
+        source,
+        context
+    });
+    entry.lastResult = success ? 'correct' : 'incorrect';
+    saveSrsProgress();
+}
+
+function saveSrsProgress() {
+    writeToLocalStorage(STORAGE_KEYS.srs, JSON.stringify(state.srs));
+}
+
+function handleReadingSelection(questionId, selectedOption) {
+    if (!questionId || !selectedOption) return;
+    const question = state.readingQuestions.find((item) => item.id === questionId);
+    if (!question || state.readingResults[questionId]) return;
+
+    const isCorrectLocal = normaliseAnswer(selectedOption) === normaliseAnswer(question.answerKey || question.focusWords[0]);
+    state.readingResults[questionId] = {
+        status: isCorrectLocal ? 'correct' : 'incorrect',
+        explanation: isCorrectLocal ? '选择正确！' : '再想想情境中的线索。',
+        selected: selectedOption,
+        confirmed: false
+    };
+    renderStudy();
+    updateSrsForQuestion(question, isCorrectLocal, 'instant');
+    evaluateReadingAnswer(questionId, selectedOption, question).catch((error) => {
+        console.warn('Reading evaluation failed', error);
+    });
+}
+
+async function evaluateReadingAnswer(questionId, selectedOption, question) {
+    if (!state.sessionId) return;
+    try {
+        const response = await fetch(`/api/ielts/reading/${state.sessionId}/evaluate`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ answers: [{ question_id: questionId, answer: selectedOption }] })
+        });
+        if (!response.ok) {
+            throw new Error(`判分失败：${response.status}`);
+        }
+        const data = await response.json();
+        if (!data || !Array.isArray(data.breakdown)) return;
+        const detail = data.breakdown.find((item) => item.question_id === questionId);
+        if (!detail) return;
+        const isCorrect = Boolean(detail.correct);
+        const rationale = detail.rationale || question.hint || '';
+        state.readingResults[questionId] = {
+            status: isCorrect ? 'correct' : 'incorrect',
+            explanation: rationale,
+            selected: selectedOption,
+            confirmed: true,
+            reference: detail.correct_answer
+        };
+        renderStudy();
+        updateSrsForQuestion(question, isCorrect, 'evaluate');
+    } catch (error) {
+        console.warn(error);
+        const result = state.readingResults[questionId];
+        if (result && !result.confirmed) {
+            result.explanation = `${result.explanation || ''}（暂未获取解析）`;
+            renderStudy();
+        }
+    }
+}
+
+function updateSrsForQuestion(question, isCorrect, source) {
+    const focusWords = question.focusWords && question.focusWords.length
+        ? question.focusWords
+        : [question.answerKey].filter(Boolean);
+    focusWords
+        .map((word) => (word || '').toLowerCase())
+        .filter(Boolean)
+        .forEach((word) => updateSrsEntry(word, isCorrect, source, { questionId: question.id }));
+    renderReview();
+}
+
+function handleReviewAction(wordId, success) {
+    updateSrsEntry(wordId, success, 'manual');
+    renderReview();
+}
+
+function computeDailyReviewList() {
+    const entries = Object.values(state.srs.words || {}).map((entry) => ({ ...entry, id: entry.id || entry.lemma.toLowerCase() }));
+    const endOfToday = new Date();
+    endOfToday.setHours(23, 59, 59, 999);
+    const due = entries
+        .filter((entry) => (entry.nextReview || 0) <= endOfToday.getTime())
+        .sort((a, b) => (a.nextReview || 0) - (b.nextReview || 0));
+    let overflowCount = 0;
+    if (due.length > 20) {
+        const overflow = due.splice(20);
+        overflowCount = overflow.length;
+        const startOfTomorrow = new Date();
+        startOfTomorrow.setHours(24, 0, 0, 0);
+        overflow.forEach((entry, index) => {
+            const newTime = startOfTomorrow.getTime() + index * 60 * 1000;
+            state.srs.words[entry.id].nextReview = newTime;
+        });
+        saveSrsProgress();
+    }
+    return { dueToday: due, overflowCount };
+}
+
+function getActiveGeminiApiKey() {
+    const input = elements.geminiInput;
+    if (input && typeof input.value === 'string' && input.value.trim()) {
+        return input.value.trim();
+    }
+    const stored = getStoredGeminiKey();
+    return stored || '';
+}
+
+function initialiseGeminiKeyControls() {
+    const apiInput = elements.geminiInput;
+    const rememberCheckbox = elements.rememberCheckbox;
+    if (!apiInput || !rememberCheckbox) {
+        return;
+    }
+    const storedKey = getStoredGeminiKey();
+    let remember = shouldRememberGeminiKey();
+    if (storedKey && !remember) {
+        remember = true;
+        writeToLocalStorage(GEMINI_REMEMBER_STORAGE_KEY, 'true');
+    }
+    rememberCheckbox.checked = remember;
+    if (remember && storedKey) {
+        apiInput.value = storedKey;
+    }
+    rememberCheckbox.addEventListener('change', () => {
+        const shouldRemember = rememberCheckbox.checked;
+        persistRememberPreference(shouldRemember);
+        if (shouldRemember && apiInput.value.trim()) {
+            persistGeminiKey(apiInput.value.trim());
+        }
+    });
+    apiInput.addEventListener('input', () => {
+        if (rememberCheckbox.checked) {
+            persistGeminiKey(apiInput.value);
+        }
+    });
+}
+
+function getStoredGeminiKey() {
+    return readFromLocalStorage(GEMINI_KEY_STORAGE_KEY) || '';
+}
+
+function shouldRememberGeminiKey() {
+    return readFromLocalStorage(GEMINI_REMEMBER_STORAGE_KEY) === 'true';
+}
+
+function persistGeminiKey(value) {
+    if (value && value.trim()) {
+        writeToLocalStorage(GEMINI_KEY_STORAGE_KEY, value.trim());
+    } else {
+        removeFromLocalStorage(GEMINI_KEY_STORAGE_KEY);
+    }
+}
+
+function persistRememberPreference(remember) {
+    writeToLocalStorage(GEMINI_REMEMBER_STORAGE_KEY, remember ? 'true' : 'false');
+    if (!remember) {
+        removeFromLocalStorage(GEMINI_KEY_STORAGE_KEY);
+    }
+}
+
+function guessPartOfSpeech(word) {
+    const lower = (word || '').toLowerCase();
+    if (/ly$/.test(lower)) return 'adv.';
+    if (/(tion|ment|ness|ity|ship|ence|ance)$/.test(lower)) return 'n.';
+    if (/(able|ible|ous|ive|ful|less|al|ic)$/.test(lower)) return 'adj.';
+    if (/(ing|ed)$/.test(lower)) return 'v.';
+    return 'n.';
+}
+
+function normalisePhonetic(value) {
+    if (!value) return '';
+    const text = String(value).trim();
+    if (!text) return '';
+    return text.startsWith('/') ? text : `/${text}/`;
+}
+
+function buildPseudoPhonetic(word) {
+    const lower = (word || '').toLowerCase().replace(/[^a-z]/g, '');
+    if (!lower) return '—';
+    const map = { a: 'æ', e: 'e', i: 'ɪ', o: 'ɒ', u: 'ʌ', c: 'k', g: 'g', y: 'i', x: 'ks' };
+    const phonetic = lower
+        .split('')
+        .map((char) => map[char] || char)
+        .join('');
+    return `/${phonetic}/`;
+}
+
+function truncateWords(text, limit) {
+    if (!text) return '';
+    const words = String(text).split(/\s+/).filter(Boolean);
+    if (words.length <= limit) return String(text);
+    return `${words.slice(0, limit).join(' ')}…`;
+}
+
+function normaliseAnswer(text) {
+    return String(text || '').toLowerCase().replace(/[^a-z]/g, '');
+}
+
+function formatRelativeTime(timestamp) {
+    if (!timestamp) return '刚刚';
+    const diff = Date.now() - Number(timestamp);
+    if (diff < 60 * 1000) return '刚刚';
+    if (diff < 3600 * 1000) return `${Math.floor(diff / (60 * 1000))} 分钟前`;
+    if (diff < 24 * 3600 * 1000) return `${Math.floor(diff / (3600 * 1000))} 小时前`;
+    return `${Math.floor(diff / (24 * 3600 * 1000))} 天前`;
+}
+
+function formatDate(timestamp) {
+    if (!timestamp) return '今日';
+    const date = new Date(timestamp);
+    return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+}
+
+function capitalize(text) {
+    if (!text) return '';
+    const str = String(text);
+    return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+function stringHash(text) {
+    let hash = 0;
+    const str = String(text);
+    for (let i = 0; i < str.length; i += 1) {
+        hash = (hash << 5) - hash + str.charCodeAt(i);
+        hash |= 0;
+    }
+    return Math.abs(hash);
 }
 
 function escapeHtml(value) {
-    if (value == null) {
-        return '';
-    }
+    if (value == null) return '';
     return String(value)
         .replace(/&/g, '&amp;')
         .replace(/</g, '&lt;')
         .replace(/>/g, '&gt;')
         .replace(/"/g, '&quot;')
         .replace(/'/g, '&#39;');
+}
+
+function escapeAttribute(value) {
+    return escapeHtml(value).replace(/"/g, '&quot;');
+}
+
+function safeParseJson(text, fallback) {
+    if (!text) return fallback;
+    try {
+        return JSON.parse(text);
+    } catch (error) {
+        return fallback;
+    }
+}
+
+function readFromLocalStorage(key) {
+    try {
+        return window.localStorage ? window.localStorage.getItem(key) : null;
+    } catch (error) {
+        return null;
+    }
+}
+
+function writeToLocalStorage(key, value) {
+    try {
+        if (window.localStorage) {
+            window.localStorage.setItem(key, value);
+        }
+    } catch (error) {
+        console.warn('Unable to write localStorage', error);
+    }
+}
+
+function removeFromLocalStorage(key) {
+    try {
+        if (window.localStorage) {
+            window.localStorage.removeItem(key);
+        }
+    } catch (error) {
+        console.warn('Unable to remove from localStorage', error);
+    }
 }

--- a/frontend/features/ielts-study-system/styles.css
+++ b/frontend/features/ielts-study-system/styles.css
@@ -1,0 +1,730 @@
+:root {
+    --ielts-accent: #4f5fff;
+    --ielts-accent-soft: #eef0ff;
+    --ielts-border: #dfe3f7;
+    --ielts-text-muted: #6a728a;
+    --ielts-card-bg: #ffffff;
+    --ielts-skeleton-from: rgba(111, 126, 255, 0.08);
+    --ielts-skeleton-to: rgba(111, 126, 255, 0.2);
+}
+
+body.ielts-theme {
+    background: #f5f7ff;
+}
+
+.ielts-app {
+    max-width: 1180px;
+    margin: 48px auto;
+    padding: 32px 36px;
+    background: linear-gradient(180deg, rgba(79, 95, 255, 0.08), rgba(255, 255, 255, 0));
+    border-radius: 28px;
+    backdrop-filter: blur(6px);
+}
+
+.app-header {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-bottom: 32px;
+}
+
+.app-header h1 {
+    font-size: 2.2rem;
+    color: #1f2355;
+    margin-bottom: 4px;
+}
+
+.app-header p {
+    color: var(--ielts-text-muted);
+    max-width: 680px;
+}
+
+.back-link {
+    color: #4f5fff;
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.back-link:hover {
+    text-decoration: underline;
+}
+
+.tab-nav {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    border: 1px solid var(--ielts-border);
+    background: rgba(255, 255, 255, 0.8);
+    backdrop-filter: blur(4px);
+    padding: 6px;
+    border-radius: 999px;
+    align-self: flex-start;
+}
+
+.tab-nav button {
+    border: none;
+    background: transparent;
+    padding: 10px 20px;
+    border-radius: 999px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--ielts-text-muted);
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.tab-nav button.is-active {
+    background: var(--ielts-accent);
+    color: white;
+    box-shadow: 0 10px 25px rgba(79, 95, 255, 0.25);
+}
+
+.app-main {
+    display: block;
+}
+
+.view {
+    display: none;
+}
+
+.view.view-active {
+    display: block;
+}
+
+.panel {
+    background: rgba(255, 255, 255, 0.96);
+    border-radius: 22px;
+    padding: 24px 28px;
+    box-shadow: 0 15px 45px rgba(15, 24, 80, 0.08);
+    border: 1px solid rgba(79, 95, 255, 0.08);
+}
+
+.panel-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 18px;
+}
+
+.panel-header h2 {
+    font-size: 1.3rem;
+    color: #1f2355;
+}
+
+.panel-subtitle {
+    color: var(--ielts-text-muted);
+    font-size: 0.92rem;
+    margin-bottom: 18px;
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 12px;
+    font-size: 0.82rem;
+    border-radius: 999px;
+    background: var(--ielts-accent-soft);
+    color: var(--ielts-accent);
+    font-weight: 600;
+}
+
+.home-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+    gap: 24px;
+}
+
+.upload-dropzone {
+    position: relative;
+    border: 2px dashed var(--ielts-border);
+    border-radius: 18px;
+    padding: 38px 24px;
+    text-align: center;
+    background: rgba(255, 255, 255, 0.65);
+    transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.upload-dropzone.drag-over {
+    border-color: var(--ielts-accent);
+    background: rgba(79, 95, 255, 0.08);
+}
+
+.upload-dropzone .dropzone-icon {
+    font-size: 2rem;
+    margin-bottom: 12px;
+}
+
+.upload-dropzone button {
+    background: var(--ielts-accent);
+    color: white;
+    border: none;
+    border-radius: 10px;
+    padding: 8px 18px;
+    cursor: pointer;
+    font-weight: 600;
+    margin: 0 4px;
+}
+
+.upload-tip {
+    font-size: 0.85rem;
+    color: var(--ielts-text-muted);
+    margin-top: 12px;
+}
+
+.progress-container {
+    margin-top: 20px;
+    display: none;
+    align-items: center;
+    gap: 12px;
+}
+
+.progress-container.active {
+    display: flex;
+}
+
+.progress-bar {
+    position: relative;
+    flex: 1;
+    height: 8px;
+    border-radius: 999px;
+    background: var(--ielts-accent-soft);
+    overflow: hidden;
+}
+
+.progress-bar span {
+    position: absolute;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    width: 0%;
+    border-radius: 999px;
+    background: var(--ielts-accent);
+    transition: width 0.2s ease;
+}
+
+.error-message {
+    min-height: 20px;
+    margin-top: 14px;
+    color: #d64545;
+    font-size: 0.9rem;
+}
+
+.api-key-config {
+    margin-top: 26px;
+    padding: 16px 18px;
+    border-radius: 16px;
+    background: rgba(79, 95, 255, 0.05);
+    border: 1px solid rgba(79, 95, 255, 0.1);
+}
+
+.api-key-config label {
+    font-weight: 600;
+    color: #1f2355;
+}
+
+.api-key-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-top: 10px;
+}
+
+.api-key-row input[type="password"] {
+    flex: 1;
+    border: 1px solid var(--ielts-border);
+    border-radius: 10px;
+    padding: 10px 12px;
+    font-size: 0.95rem;
+}
+
+.remember-key {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 0.85rem;
+    color: var(--ielts-text-muted);
+}
+
+.recent-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 14px;
+    min-height: 180px;
+}
+
+.recent-card {
+    border-radius: 16px;
+    padding: 12px;
+    background: rgba(255, 255, 255, 0.8);
+    border: 1px solid rgba(79, 95, 255, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.recent-card img {
+    width: 100%;
+    border-radius: 12px;
+    object-fit: cover;
+    aspect-ratio: 4 / 3;
+}
+
+.recent-card .recent-meta {
+    font-size: 0.8rem;
+    color: var(--ielts-text-muted);
+}
+
+.study-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 5fr) minmax(0, 4fr);
+    gap: 24px;
+}
+
+.image-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+}
+
+.image-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.asset-strip {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.asset-thumb {
+    border: 1px solid rgba(79, 95, 255, 0.18);
+    border-radius: 14px;
+    padding: 4px;
+    background: rgba(255, 255, 255, 0.9);
+    cursor: pointer;
+    transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.asset-thumb img {
+    height: 44px;
+    width: 58px;
+    object-fit: cover;
+    border-radius: 10px;
+    display: block;
+}
+
+.asset-thumb.is-active {
+    border-color: var(--ielts-accent);
+    box-shadow: 0 10px 25px rgba(79, 95, 255, 0.16);
+    transform: translateY(-2px);
+}
+
+.zoom-controls {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.zoom-controls button {
+    width: 34px;
+    height: 34px;
+    border-radius: 50%;
+    border: none;
+    background: var(--ielts-accent);
+    color: white;
+    font-weight: bold;
+    cursor: pointer;
+}
+
+.image-viewer {
+    position: relative;
+    flex: 1;
+    background: rgba(255, 255, 255, 0.7);
+    border-radius: 18px;
+    border: 1px solid rgba(79, 95, 255, 0.1);
+    overflow: hidden;
+    min-height: 320px;
+}
+
+.image-viewport {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    cursor: grab;
+}
+
+.image-viewport:active {
+    cursor: grabbing;
+}
+
+.image-stage {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform-origin: center center;
+    --translate-x: 0px;
+    --translate-y: 0px;
+    --scale: 1;
+    transform: translate(calc(-50% + var(--translate-x)), calc(-50% + var(--translate-y))) scale(var(--scale));
+}
+
+.image-stage img {
+    display: block;
+    max-width: none;
+    width: auto;
+    height: auto;
+    border-radius: 16px;
+    box-shadow: 0 10px 30px rgba(15, 24, 80, 0.12);
+}
+
+.bbox-layer {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    pointer-events: none;
+}
+
+.bbox-box {
+    position: absolute;
+    border: 2px solid rgba(79, 95, 255, 0.8);
+    border-radius: 10px;
+    background: rgba(79, 95, 255, 0.08);
+    pointer-events: auto;
+    transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.bbox-box::after {
+    content: attr(data-label);
+    position: absolute;
+    left: 4px;
+    bottom: 4px;
+    padding: 2px 6px;
+    border-radius: 6px;
+    background: rgba(79, 95, 255, 0.9);
+    color: white;
+    font-size: 0.72rem;
+    font-weight: 600;
+}
+
+.bbox-box.is-highlighted {
+    border-color: #ff7c6b;
+    background: rgba(255, 124, 107, 0.12);
+    box-shadow: 0 0 0 3px rgba(255, 124, 107, 0.15);
+}
+
+.bbox-box.is-active {
+    border-color: #ff3d00;
+    background: rgba(255, 61, 0, 0.16);
+}
+
+.image-placeholder {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--ielts-text-muted);
+    font-size: 0.95rem;
+    pointer-events: none;
+}
+
+.word-list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 16px;
+    max-height: 420px;
+    overflow-y: auto;
+    padding-right: 6px;
+}
+
+.word-card {
+    position: relative;
+    padding: 18px;
+    border-radius: 16px;
+    border: 1px solid rgba(79, 95, 255, 0.08);
+    background: rgba(255, 255, 255, 0.92);
+    box-shadow: 0 10px 25px rgba(15, 24, 80, 0.05);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.word-card.is-highlighted {
+    transform: translateY(-3px);
+    box-shadow: 0 20px 45px rgba(79, 95, 255, 0.18);
+    border-color: rgba(79, 95, 255, 0.4);
+}
+
+.word-card.is-active {
+    border-color: #ff7c6b;
+}
+
+.word-card header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 12px;
+}
+
+.word-card h3 {
+    font-size: 1.1rem;
+    color: #1f2355;
+}
+
+.word-meta {
+    font-size: 0.85rem;
+    color: var(--ielts-text-muted);
+}
+
+.word-definition {
+    font-size: 0.92rem;
+    margin-bottom: 10px;
+    color: #31385a;
+}
+
+.word-example {
+    font-size: 0.85rem;
+    color: var(--ielts-text-muted);
+    margin-bottom: 12px;
+}
+
+.word-topics {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.topic-chip {
+    display: inline-flex;
+    align-items: center;
+    padding: 2px 8px;
+    font-size: 0.74rem;
+    border-radius: 999px;
+    background: rgba(79, 95, 255, 0.12);
+    color: #4f5fff;
+}
+
+.favorite-toggle {
+    border: none;
+    background: none;
+    color: #ffb347;
+    cursor: pointer;
+    font-size: 1.2rem;
+    line-height: 1;
+}
+
+.favorite-toggle[aria-pressed="false"] {
+    color: rgba(0, 0, 0, 0.2);
+}
+
+.reading-quiz {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.reading-question {
+    border-radius: 18px;
+    border: 1px solid rgba(79, 95, 255, 0.1);
+    padding: 18px;
+    background: rgba(255, 255, 255, 0.92);
+}
+
+.question-header {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    margin-bottom: 12px;
+}
+
+.question-index {
+    width: 28px;
+    height: 28px;
+    border-radius: 50%;
+    background: var(--ielts-accent);
+    color: white;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 600;
+}
+
+.option-list {
+    display: grid;
+    gap: 8px;
+    margin-bottom: 12px;
+}
+
+.reading-option {
+    border-radius: 12px;
+    padding: 10px 14px;
+    border: 1px solid rgba(79, 95, 255, 0.2);
+    background: rgba(255, 255, 255, 0.85);
+    text-align: left;
+    cursor: pointer;
+    transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+.reading-option:hover {
+    transform: translateX(4px);
+    border-color: var(--ielts-accent);
+}
+
+.reading-option.is-selected {
+    border-color: var(--ielts-accent);
+    background: rgba(79, 95, 255, 0.12);
+}
+
+.reading-option.is-correct {
+    border-color: #2ecc71;
+    background: rgba(46, 204, 113, 0.12);
+}
+
+.reading-option.is-incorrect {
+    border-color: #e74c3c;
+    background: rgba(231, 76, 60, 0.12);
+}
+
+.question-hint {
+    font-size: 0.85rem;
+    color: var(--ielts-text-muted);
+}
+
+.question-result {
+    font-size: 0.88rem;
+    margin-top: 6px;
+}
+
+.question-result.correct {
+    color: #2ecc71;
+}
+
+.question-result.incorrect {
+    color: #e74c3c;
+}
+
+.review-list {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.review-item {
+    border-radius: 18px;
+    padding: 18px;
+    border: 1px solid rgba(79, 95, 255, 0.1);
+    background: rgba(255, 255, 255, 0.9);
+    display: grid;
+    grid-template-columns: minmax(0, 2fr) minmax(0, 3fr) minmax(0, 2fr);
+    gap: 18px;
+    align-items: center;
+}
+
+.review-word h3 {
+    font-size: 1.1rem;
+    color: #1f2355;
+}
+
+.review-word p {
+    font-size: 0.85rem;
+    color: var(--ielts-text-muted);
+}
+
+.review-definition {
+    font-size: 0.9rem;
+    color: #2f3a69;
+}
+
+.review-actions {
+    display: flex;
+    gap: 10px;
+    justify-content: flex-end;
+}
+
+.review-btn {
+    border: none;
+    border-radius: 999px;
+    padding: 8px 18px;
+    font-weight: 600;
+    cursor: pointer;
+    background: rgba(79, 95, 255, 0.12);
+    color: var(--ielts-accent);
+}
+
+.review-btn.primary {
+    background: var(--ielts-accent);
+    color: white;
+}
+
+.review-meta {
+    font-size: 0.78rem;
+    color: var(--ielts-text-muted);
+    margin-top: 8px;
+}
+
+.panel-note {
+    margin-top: 14px;
+    color: var(--ielts-text-muted);
+    font-size: 0.85rem;
+}
+
+.skeleton-block {
+    border-radius: 14px;
+    background: linear-gradient(90deg, var(--ielts-skeleton-from), var(--ielts-skeleton-to), var(--ielts-skeleton-from));
+    background-size: 200% 100%;
+    animation: skeletonPulse 1.6s ease-in-out infinite;
+}
+
+.skeleton-line {
+    height: 12px;
+    border-radius: 999px;
+    margin-bottom: 10px;
+}
+
+.skeleton-thumb {
+    width: 100%;
+    aspect-ratio: 4 / 3;
+    border-radius: 12px;
+}
+
+.empty-placeholder {
+    text-align: center;
+    color: var(--ielts-text-muted);
+    padding: 40px 0;
+}
+
+@keyframes skeletonPulse {
+    0% {
+        background-position: 200% 0;
+    }
+    100% {
+        background-position: -200% 0;
+    }
+}
+
+@media (max-width: 1024px) {
+    .home-grid,
+    .study-layout,
+    .review-item {
+        grid-template-columns: 1fr;
+    }
+
+    .review-item {
+        grid-template-rows: auto;
+    }
+
+    .ielts-app {
+        padding: 24px;
+    }
+
+    .asset-strip {
+        flex-wrap: wrap;
+    }
+}


### PR DESCRIPTION
## Summary
- build a tabbed IELTS learning experience with dedicated上传、学习、复习视图和骨架屏
- implement drag/drop image uploading with validation, progress feedback, deterministic bbox overlays, and enriched词卡展示
- add阅读填空即时判分与SRS本地复习队列，并允许后端按题判分

## Testing
- python -m compileall backend/features/ielts_study_system

------
https://chatgpt.com/codex/tasks/task_e_68d3e5015a0c833294e1f30d978de6f4