### PR TITLE
feat: restore firecrawl exporter with refined hero copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ flashmvp 是一个专为快速产品验证设计的混合云框架。它将 `fla
 
   - 功能模块（`features/`）保持高度独立，新增功能不影响平台核心，便于团队协作和 LLM 辅助开发。
 
+### 🔄 Firecrawl Markdown 导出器（新增）
+
+  - 后端新增 `firecrawl_exporter` 功能模块，调用开源项目 [Firecrawl](https://github.com/firecrawl/firecrawl) 的爬虫能力，将指定站点的当前页面及子页面转化为 Markdown。
+  - 前端提供独立的「🪄 Firecrawl Markdown 导出器」界面，输入网址即可发起任务、追踪进度并下载归档 ZIP 文件。
+  - 通过环境变量配置 `FIRECRAWL_API_KEY`（必填）和 `FIRECRAWL_BASE_URL`（选填，默认官方云服务）即可完成接入，不影响现有功能。
+
 ## 🏗️ 技术架构
 
 1.  **用户请求** 首先到达 **Cloudflare Pages**。

--- a/backend/features/firecrawl_exporter/__init__.py
+++ b/backend/features/firecrawl_exporter/__init__.py
@@ -1,0 +1,3 @@
+"""Firecrawl-powered site exporter feature package."""
+
+__all__ = ["router"]

--- a/backend/features/firecrawl_exporter/router.py
+++ b/backend/features/firecrawl_exporter/router.py
@@ -1,0 +1,403 @@
+"""Firecrawl site exporter feature.
+
+This module exposes a small REST API that proxies the open source
+`firecrawl` project (https://github.com/firecrawl/firecrawl).  It allows
+frontend users to submit a URL, waits for Firecrawl to finish crawling the
+site (current page + child pages) and produces a downloadable Markdown
+archive.  All logic is isolated in this feature package so existing modules
+remain unaffected.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import re
+import zipfile
+from datetime import datetime, timezone
+from typing import Dict, Iterable, List, Optional
+
+import requests
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import StreamingResponse
+from pydantic import BaseModel, Field, HttpUrl
+
+router = APIRouter(
+    prefix="/firecrawl-exporter",
+    tags=["Firecrawl Exporter"],
+)
+
+DEFAULT_MAX_DEPTH = 2
+DEFAULT_MAX_PAGES = 25
+MAX_ALLOWED_PAGES = 200
+
+
+class CrawlRequest(BaseModel):
+    """Payload used to start a crawl job."""
+
+    url: HttpUrl = Field(..., description="Root URL to crawl")
+    max_depth: int = Field(
+        DEFAULT_MAX_DEPTH,
+        ge=0,
+        le=8,
+        description="How deep Firecrawl should follow links from the root page.",
+    )
+    max_pages: int = Field(
+        DEFAULT_MAX_PAGES,
+        ge=1,
+        le=MAX_ALLOWED_PAGES,
+        description="Maximum number of pages to capture.",
+    )
+    include_subdomains: bool = Field(
+        False,
+        description="Whether to include subdomains while crawling.",
+    )
+    ignore_sitemap: bool = Field(
+        False,
+        description="If true the Firecrawl crawler will ignore sitemap.xml hints.",
+    )
+
+
+class CrawlJobStartResponse(BaseModel):
+    """Response returned when a crawl job has been created."""
+
+    job_id: str = Field(..., description="Firecrawl job identifier")
+    firecrawl_status: str = Field(..., description="Raw status reported by Firecrawl")
+    detail: str = Field(..., description="Human readable status message")
+    poll_after_seconds: float = Field(
+        2.5,
+        description="Suggested delay before polling job status again.",
+    )
+
+
+class CrawlJobStatus(BaseModel):
+    """Represents the status of an existing crawl job."""
+
+    job_id: str
+    status: str = Field(..., description="Normalized job status")
+    firecrawl_status: str = Field(..., description="Raw status reported by Firecrawl")
+    page_count: Optional[int] = Field(None, description="Number of Markdown pages ready")
+    download_url: Optional[str] = Field(
+        None,
+        description="Relative API endpoint for downloading the Markdown archive.",
+    )
+    detail: Optional[str] = Field(None, description="Human readable explanation")
+    last_updated: Optional[str] = Field(
+        None,
+        description="ISO timestamp when Firecrawl last updated the job.",
+    )
+
+
+def _require_firecrawl_headers() -> Dict[str, str]:
+    """Builds the authorization headers for Firecrawl's REST API."""
+
+    api_key = os.getenv("FIRECRAWL_API_KEY")
+    if not api_key:
+        raise HTTPException(
+            status_code=500,
+            detail=(
+                "FIRECRAWL_API_KEY environment variable is not configured. "
+                "Please supply a valid Firecrawl API key before using this feature."
+            ),
+        )
+
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+
+
+def _firecrawl_base_url() -> str:
+    """Returns the configured Firecrawl base URL."""
+
+    base_url = os.getenv("FIRECRAWL_BASE_URL", "https://api.firecrawl.dev")
+    return base_url.rstrip("/")
+
+
+def _build_crawl_payload(request: CrawlRequest) -> Dict[str, object]:
+    """Constructs a payload compatible with Firecrawl's crawl endpoint."""
+
+    crawl_options = {
+        "maxDepth": request.max_depth,
+        "limit": min(request.max_pages, MAX_ALLOWED_PAGES),
+        "includeSubdomains": request.include_subdomains,
+        "ignoreSitemap": request.ignore_sitemap,
+        "allowUntrustedCertificates": False,
+    }
+
+    return {
+        "url": str(request.url),
+        "maxDepth": crawl_options["maxDepth"],
+        "limit": crawl_options["limit"],
+        "includeSubdomains": crawl_options["includeSubdomains"],
+        "ignoreSitemap": crawl_options["ignoreSitemap"],
+        "formats": ["markdown"],
+        "options": {
+            "crawl": crawl_options,
+            "formats": ["markdown"],
+        },
+    }
+
+
+def _call_firecrawl(
+    method: str,
+    path: str,
+    *,
+    json_payload: Optional[Dict[str, object]] = None,
+) -> Dict[str, object]:
+    """Performs an HTTP request against the Firecrawl API."""
+
+    headers = _require_firecrawl_headers()
+    url = f"{_firecrawl_base_url()}{path}"
+
+    try:
+        response = requests.request(
+            method,
+            url,
+            headers=headers,
+            json=json_payload,
+            timeout=120,
+        )
+    except requests.RequestException as exc:  # pragma: no cover - network errors at runtime only
+        raise HTTPException(
+            status_code=502,
+            detail=f"Failed to reach Firecrawl API: {exc}",
+        ) from exc
+
+    if response.status_code >= 400:
+        try:
+            payload = response.json()
+        except ValueError:
+            payload = {"detail": response.text}
+
+        raise HTTPException(
+            status_code=response.status_code,
+            detail=payload.get("detail") or payload.get("message") or "Firecrawl API error",
+        )
+
+    try:
+        return response.json()
+    except ValueError as exc:  # pragma: no cover - defensive guard
+        raise HTTPException(
+            status_code=502,
+            detail="Firecrawl API returned invalid JSON response.",
+        ) from exc
+
+
+def _normalize_status(status: str) -> str:
+    normalized = status.lower()
+    if normalized in {"done", "completed", "succeeded"}:
+        return "completed"
+    if normalized in {"running", "processing", "in_progress"}:
+        return "running"
+    if normalized in {"queued", "pending"}:
+        return "queued"
+    if normalized in {"failed", "error"}:
+        return "failed"
+    return normalized
+
+
+def _extract_markdown_pages(data: Iterable[Dict[str, object]]) -> List[Dict[str, str]]:
+    """Extracts markdown strings from Firecrawl's crawl payload."""
+
+    pages: List[Dict[str, str]] = []
+    for index, page in enumerate(data, start=1):
+        markdown: Optional[str] = None
+        title: Optional[str] = None
+
+        if isinstance(page, dict):
+            if isinstance(page.get("markdown"), str):
+                markdown = page["markdown"]
+            elif isinstance(page.get("content"), dict):
+                content = page["content"]
+                if isinstance(content.get("markdown"), str):
+                    markdown = content["markdown"]
+                elif isinstance(content.get("md"), str):
+                    markdown = content["md"]
+
+            metadata = page.get("metadata")
+            if isinstance(metadata, dict) and isinstance(metadata.get("title"), str):
+                title = metadata.get("title")
+            elif isinstance(page.get("title"), str):
+                title = page["title"]
+
+            if not title and isinstance(page.get("url"), str):
+                title = page["url"]
+
+        if not markdown:
+            continue
+
+        pages.append(
+            {
+                "index": index,
+                "title": title or f"Page {index}",
+                "markdown": markdown,
+            }
+        )
+
+    return pages
+
+
+def _slugify(text: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", text)
+    slug = re.sub(r"-+", "-", slug).strip("-")
+    return slug.lower() or "page"
+
+
+def _build_zip_archive(pages: List[Dict[str, str]], root_url: str) -> io.BytesIO:
+    """Converts page markdown data into a downloadable zip archive."""
+
+    buffer = io.BytesIO()
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S %Z")
+
+    with zipfile.ZipFile(buffer, "w", compression=zipfile.ZIP_DEFLATED) as zip_file:
+        combined_sections: List[str] = []
+        metadata: Dict[str, object] = {
+            "generated_at": timestamp,
+            "source_url": root_url,
+            "page_count": len(pages),
+            "pages": [],
+        }
+
+        for page in pages:
+            index = page["index"]
+            title = page["title"]
+            markdown = page["markdown"]
+            slug = _slugify(title)
+            filename = f"{index:02d}-{slug}.md"
+            header = f"# {title}\n\n" if not markdown.lstrip().startswith("#") else ""
+            zip_file.writestr(filename, f"{header}{markdown}")
+            combined_sections.append(f"## {title}\n\n{markdown}")
+            metadata["pages"].append({
+                "index": index,
+                "title": title,
+                "filename": filename,
+            })
+
+        overview = (
+            f"# Firecrawl Export Summary\n\n"
+            f"- Generated at: {timestamp}\n"
+            f"- Source URL: {root_url}\n"
+            f"- Markdown pages: {len(pages)}\n\n"
+            "Each page is exported as an individual Markdown file in this archive."
+        )
+        zip_file.writestr("README.md", overview)
+        zip_file.writestr("full-site.md", "\n\n---\n\n".join(combined_sections))
+        zip_file.writestr(
+            "metadata.json",
+            json.dumps(metadata, indent=2, ensure_ascii=False),
+        )
+
+    buffer.seek(0)
+    return buffer
+
+
+@router.post("/jobs", response_model=CrawlJobStartResponse)
+def create_crawl_job(request: CrawlRequest) -> CrawlJobStartResponse:
+    """Starts a new crawl job using Firecrawl's REST API."""
+
+    payload = _build_crawl_payload(request)
+    firecrawl_response = _call_firecrawl("POST", "/v1/crawl", json_payload=payload)
+
+    job_id = firecrawl_response.get("jobId") or firecrawl_response.get("id")
+    status = str(firecrawl_response.get("status") or "queued")
+
+    if not job_id:
+        raise HTTPException(
+            status_code=502,
+            detail="Firecrawl did not return a job identifier.",
+        )
+
+    detail = (
+        "Crawl job created successfully. Firecrawl is fetching pages now."
+        if _normalize_status(status) in {"queued", "running"}
+        else f"Firecrawl reported status: {status}."
+    )
+
+    return CrawlJobStartResponse(
+        job_id=job_id,
+        firecrawl_status=status,
+        detail=detail,
+    )
+
+
+@router.get("/jobs/{job_id}", response_model=CrawlJobStatus)
+def get_crawl_job_status(job_id: str) -> CrawlJobStatus:
+    """Fetches the current status for an existing crawl job."""
+
+    firecrawl_response = _call_firecrawl("GET", f"/v1/crawl/{job_id}")
+    status = str(firecrawl_response.get("status") or firecrawl_response.get("state") or "queued")
+    normalized_status = _normalize_status(status)
+
+    page_data = firecrawl_response.get("data") or firecrawl_response.get("pages")
+    page_count = None
+    if isinstance(page_data, list):
+        page_count = len(_extract_markdown_pages(page_data))
+
+    detail = firecrawl_response.get("detail") or firecrawl_response.get("message")
+    if not detail:
+        if normalized_status == "completed":
+            detail = "Crawl complete. Markdown archive is ready for download."
+        elif normalized_status == "running":
+            detail = "Crawl in progress. Firecrawl is still collecting pages."
+        elif normalized_status == "queued":
+            detail = "Crawl queued. Waiting for Firecrawl workers to start."
+        elif normalized_status == "failed":
+            detail = "Crawl failed. Please review Firecrawl logs for details."
+
+    updated_at = firecrawl_response.get("updatedAt") or firecrawl_response.get("updated_at")
+
+    download_url = None
+    if normalized_status == "completed":
+        download_url = f"/api/firecrawl-exporter/jobs/{job_id}/download"
+
+    return CrawlJobStatus(
+        job_id=job_id,
+        status=normalized_status,
+        firecrawl_status=status,
+        page_count=page_count,
+        download_url=download_url,
+        detail=detail,
+        last_updated=updated_at,
+    )
+
+
+@router.get("/jobs/{job_id}/download")
+def download_crawl_archive(job_id: str):
+    """Streams a Markdown zip archive for the given crawl job."""
+
+    firecrawl_response = _call_firecrawl("GET", f"/v1/crawl/{job_id}")
+    status = _normalize_status(str(firecrawl_response.get("status") or ""))
+
+    if status != "completed":
+        raise HTTPException(
+            status_code=409,
+            detail="Crawl is not complete yet. Please try again once Firecrawl finishes.",
+        )
+
+    page_data = firecrawl_response.get("data") or firecrawl_response.get("pages")
+    if not isinstance(page_data, list):
+        raise HTTPException(
+            status_code=502,
+            detail="Firecrawl response did not include page data.",
+        )
+
+    pages = _extract_markdown_pages(page_data)
+    if not pages:
+        raise HTTPException(
+            status_code=404,
+            detail="Firecrawl returned no Markdown content to export.",
+        )
+
+    source_url = firecrawl_response.get("url") or firecrawl_response.get("job", {}).get("url")
+    zip_buffer = _build_zip_archive(pages, root_url=source_url or "")
+
+    filename_slug = _slugify(source_url or job_id)
+    response = StreamingResponse(
+        zip_buffer,
+        media_type="application/zip",
+    )
+    response.headers["Content-Disposition"] = f"attachment; filename={filename_slug}-markdown.zip"
+    return response

--- a/backend/main.py
+++ b/backend/main.py
@@ -10,6 +10,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from features.core_api.router import router as core_api_router
 from features.chess_academy.router import router as chess_academy_router
 from features.ielts_vocab_game.router import router as ielts_vocab_game_router
+from features.firecrawl_exporter.router import router as firecrawl_exporter_router
 # ==============================================================================
 # [示例] 如何添加新的功能模块
 # ------------------------------------------------------------------------------
@@ -57,6 +58,8 @@ app.include_router(chess_academy_router, prefix="/api")
 print("✅ Successfully loaded feature: chess_academy")
 app.include_router(ielts_vocab_game_router, prefix="/api")
 print("✅ Successfully loaded feature: ielts_vocab_game")
+app.include_router(firecrawl_exporter_router, prefix="/api")
+print("✅ Successfully loaded feature: firecrawl_exporter")
 
 # ==============================================================================
 # [示例] 如何注册新的功能模块路由

--- a/frontend/config.js
+++ b/frontend/config.js
@@ -60,6 +60,12 @@ const FEATURES = [
         isFullPath: true
     },
     {
+        path: 'firecrawl-exporter/index.html',
+        name: '🪄 Firecrawl Markdown 导出器',
+        description: '输入网址，一键抓取当前站点并导出结构化 Markdown 归档。',
+        isFullPath: true
+    },
+    {
         path: 'ielts-vocab-game/index.html',
         name: '🛰️ IELTS 词汇能量舱',
         description: '成人向雅思词汇学习对战，覆盖多难度与多题型的沉浸式训练体验。',

--- a/frontend/features/firecrawl-exporter/index.html
+++ b/frontend/features/firecrawl-exporter/index.html
@@ -1,0 +1,665 @@
+<!DOCTYPE html>
+<html lang="zh-Hans">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>🪄 Firecrawl Markdown 导出器</title>
+    <link rel="stylesheet" href="../../style.css">
+    <style>
+        :root {
+            --exporter-bg: radial-gradient(circle at 12% 24%, rgba(56, 189, 248, 0.18), transparent 60%),
+                           radial-gradient(circle at 88% 0%, rgba(129, 140, 248, 0.16), transparent 62%),
+                           linear-gradient(180deg, #080b16 0%, #0c1021 45%, #080b16 100%);
+            --exporter-card: rgba(12, 17, 34, 0.78);
+            --exporter-border: rgba(148, 163, 255, 0.18);
+            --exporter-highlight: rgba(56, 189, 248, 0.22);
+            --exporter-text: rgba(226, 232, 255, 0.92);
+            --exporter-muted: rgba(203, 213, 225, 0.68);
+            --exporter-success: #34d399;
+            --exporter-danger: #f87171;
+            --exporter-warning: #fbbf24;
+        }
+
+        body {
+            font-family: 'Inter', 'Segoe UI', 'PingFang SC', 'Microsoft YaHei', sans-serif;
+            margin: 0;
+            min-height: 100vh;
+            background: var(--exporter-bg);
+            color: var(--exporter-text);
+        }
+
+        .exporter-shell {
+            max-width: 1100px;
+            margin: 0 auto;
+            padding: 32px 22px 96px;
+            display: flex;
+            flex-direction: column;
+            gap: 24px;
+        }
+
+        .hero-card {
+            position: relative;
+            border-radius: 28px;
+            padding: 32px;
+            background: linear-gradient(135deg, rgba(56, 189, 248, 0.22), rgba(129, 140, 248, 0.18));
+            border: 1px solid rgba(148, 163, 255, 0.28);
+            overflow: hidden;
+        }
+
+        .hero-card::after {
+            content: "";
+            position: absolute;
+            inset: -120px;
+            background: radial-gradient(circle at 70% 10%, rgba(129, 140, 248, 0.35), transparent 60%);
+            filter: blur(80px);
+            z-index: 0;
+        }
+
+        .hero-card > * {
+            position: relative;
+            z-index: 1;
+        }
+
+        .hero-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 10px;
+            padding: 8px 16px;
+            border-radius: 999px;
+            background: rgba(15, 23, 42, 0.55);
+            color: rgba(224, 242, 254, 0.92);
+            font-size: 0.92rem;
+            letter-spacing: 0.03em;
+            text-transform: uppercase;
+        }
+
+        .hero-card h1 {
+            font-size: clamp(1.8rem, 4vw, 2.6rem);
+            margin: 18px 0 12px;
+            line-height: 1.2;
+            font-weight: 700;
+        }
+
+        .hero-card p {
+            margin: 0;
+            max-width: 620px;
+            color: rgba(226, 232, 255, 0.78);
+            line-height: 1.7;
+        }
+
+        .panels {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 22px;
+        }
+
+        .panel {
+            background: var(--exporter-card);
+            border: 1px solid var(--exporter-border);
+            border-radius: 20px;
+            padding: 24px;
+            display: flex;
+            flex-direction: column;
+            gap: 18px;
+            box-shadow: 0 30px 45px rgba(2, 6, 23, 0.55);
+        }
+
+        .panel h2 {
+            margin: 0;
+            font-size: 1.15rem;
+            font-weight: 600;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+
+        .panel label {
+            display: block;
+            font-weight: 600;
+            margin-bottom: 6px;
+        }
+
+        input[type="url"],
+        input[type="number"],
+        select {
+            width: 100%;
+            padding: 12px 14px;
+            border-radius: 12px;
+            border: 1px solid rgba(148, 163, 255, 0.24);
+            background: rgba(12, 19, 38, 0.82);
+            color: var(--exporter-text);
+            font-size: 0.95rem;
+            box-sizing: border-box;
+        }
+
+        input[type="number"]::-webkit-inner-spin-button,
+        input[type="number"]::-webkit-outer-spin-button {
+            -webkit-appearance: none;
+            margin: 0;
+        }
+
+        .checkbox-row {
+            display: flex;
+            flex-direction: column;
+            gap: 10px;
+        }
+
+        .checkbox-row label {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            font-weight: 500;
+            color: var(--exporter-muted);
+        }
+
+        .checkbox-row input[type="checkbox"] {
+            width: 18px;
+            height: 18px;
+        }
+
+        .actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 12px;
+        }
+
+        button.primary {
+            border: none;
+            border-radius: 12px;
+            padding: 12px 22px;
+            font-weight: 600;
+            font-size: 0.95rem;
+            cursor: pointer;
+            color: #0b1120;
+            background: linear-gradient(135deg, #38bdf8, #818cf8);
+            box-shadow: 0 16px 30px rgba(56, 189, 248, 0.35);
+            transition: transform 0.18s ease, box-shadow 0.18s ease;
+        }
+
+        button.primary:disabled {
+            opacity: 0.55;
+            cursor: not-allowed;
+            box-shadow: none;
+        }
+
+        button.secondary {
+            border-radius: 12px;
+            padding: 12px 22px;
+            font-weight: 600;
+            font-size: 0.95rem;
+            cursor: pointer;
+            color: var(--exporter-text);
+            background: rgba(148, 163, 255, 0.16);
+            border: 1px solid rgba(148, 163, 255, 0.25);
+            transition: transform 0.18s ease, box-shadow 0.18s ease;
+        }
+
+        button.secondary:disabled {
+            opacity: 0.4;
+            cursor: not-allowed;
+            box-shadow: none;
+        }
+
+        button.primary:not(:disabled):hover,
+        button.secondary:not(:disabled):hover {
+            transform: translateY(-2px);
+        }
+
+        .status-card {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+            background: rgba(15, 23, 42, 0.6);
+            border-radius: 20px;
+            border: 1px solid rgba(148, 163, 255, 0.18);
+            padding: 20px 22px;
+        }
+
+        .status-row {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            flex-wrap: wrap;
+        }
+
+        .status-badge {
+            padding: 6px 14px;
+            border-radius: 999px;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+            background: rgba(148, 163, 255, 0.14);
+            color: var(--exporter-text);
+        }
+
+        .status-badge.info {
+            background: rgba(148, 163, 255, 0.18);
+            color: var(--exporter-text);
+        }
+
+        .status-badge.success {
+            background: rgba(52, 211, 153, 0.18);
+            color: var(--exporter-success);
+        }
+
+        .status-badge.warning {
+            background: rgba(251, 191, 36, 0.22);
+            color: var(--exporter-warning);
+        }
+
+        .status-badge.danger {
+            background: rgba(248, 113, 113, 0.22);
+            color: var(--exporter-danger);
+        }
+
+        .status-details {
+            color: var(--exporter-muted);
+            line-height: 1.6;
+        }
+
+        .history-table {
+            width: 100%;
+            border-collapse: collapse;
+            border-radius: 16px;
+            overflow: hidden;
+            border: 1px solid rgba(148, 163, 255, 0.12);
+        }
+
+        .history-table thead {
+            background: rgba(15, 23, 42, 0.75);
+            color: rgba(226, 232, 255, 0.78);
+        }
+
+        .history-table th,
+        .history-table td {
+            padding: 14px 16px;
+            text-align: left;
+            font-size: 0.9rem;
+        }
+
+        .history-table tbody tr:nth-child(even) {
+            background: rgba(12, 19, 38, 0.55);
+        }
+
+        .history-table tbody tr:nth-child(odd) {
+            background: rgba(15, 23, 42, 0.42);
+        }
+
+        .history-table tbody tr:hover {
+            background: rgba(56, 189, 248, 0.12);
+        }
+
+        .pill {
+            padding: 6px 12px;
+            border-radius: 999px;
+            font-weight: 600;
+            font-size: 0.8rem;
+        }
+
+        .pill.success { background: rgba(52, 211, 153, 0.16); color: var(--exporter-success); }
+        .pill.warning { background: rgba(251, 191, 36, 0.18); color: var(--exporter-warning); }
+        .pill.danger { background: rgba(248, 113, 113, 0.2); color: var(--exporter-danger); }
+        .pill.info { background: rgba(148, 163, 255, 0.2); color: var(--exporter-text); }
+
+        .hint {
+            font-size: 0.85rem;
+            color: rgba(203, 213, 225, 0.72);
+        }
+
+        @media (max-width: 768px) {
+            .hero-card {
+                padding: 24px;
+            }
+
+            .panels {
+                grid-template-columns: 1fr;
+            }
+
+            .actions {
+                flex-direction: column;
+                align-items: stretch;
+            }
+
+            button.primary,
+            button.secondary {
+                width: 100%;
+                justify-content: center;
+            }
+        }
+    </style>
+</head>
+<body>
+    <div class="exporter-shell">
+        <section class="hero-card">
+            <div class="hero-badge">🪄 Firecrawl Markdown Exporter</div>
+            <h1>Firecrawl Markdown 归档工作台</h1>
+            <p>
+                基于开源 <strong>Firecrawl</strong> 引擎，自动遍历目标站点并生成结构化的 Markdown 资料包。
+                支持多层级页面采集、任务状态追踪与 ZIP 一键导出，帮助团队在统一的演示环境中沉淀可复用内容资产。
+            </p>
+        </section>
+
+        <section class="panels">
+            <article class="panel">
+                <h2>1️⃣ 配置目标站点</h2>
+                <div>
+                    <label for="targetUrl">目标网址</label>
+                    <input type="url" id="targetUrl" placeholder="https://example.com" required>
+                    <p class="hint">请输入以 http 或 https 开头的完整地址。</p>
+                </div>
+                <div class="grid-options">
+                    <label for="maxDepth">抓取深度 (0-8)</label>
+                    <input type="number" id="maxDepth" min="0" max="8" value="2">
+                </div>
+                <div class="grid-options">
+                    <label for="maxPages">页面数量上限 (1-200)</label>
+                    <input type="number" id="maxPages" min="1" max="200" value="25">
+                </div>
+                <div class="checkbox-row">
+                    <label><input type="checkbox" id="includeSubdomains"> 同时包含子域名</label>
+                    <label><input type="checkbox" id="ignoreSitemap"> 忽略 sitemap.xml 提示</label>
+                </div>
+                <div class="actions">
+                    <button class="primary" id="startBtn">🚀 开始解析</button>
+                    <button class="secondary" id="downloadBtn" disabled>⬇️ 下载 Markdown</button>
+                </div>
+                <p class="hint">启动后系统会自动轮询 Firecrawl 任务，完成即可下载归档 ZIP。</p>
+            </article>
+
+            <article class="panel">
+                <h2>2️⃣ 任务进度</h2>
+                <div class="status-card">
+                    <div class="status-row">
+                        <span class="status-badge info" id="statusBadge">尚未开始</span>
+                        <span id="pageCount" class="hint">—</span>
+                    </div>
+                    <div class="status-details" id="statusDetails">
+                        准备就绪。提交任务后这里将展示实时进度与说明。
+                    </div>
+                    <div class="status-details hint" id="jobMeta"></div>
+                </div>
+            </article>
+        </section>
+
+        <section class="panel">
+            <h2>3️⃣ 历史记录</h2>
+            <table class="history-table">
+                <thead>
+                    <tr>
+                        <th>时间</th>
+                        <th>网址</th>
+                        <th>状态</th>
+                        <th>页面数</th>
+                        <th>操作</th>
+                    </tr>
+                </thead>
+                <tbody id="historyBody">
+                    <tr>
+                        <td colspan="5" class="hint">暂无任务，赶快试试看吧！</td>
+                    </tr>
+                </tbody>
+            </table>
+        </section>
+    </div>
+
+    <script>
+        const API_PREFIX = '/api/firecrawl-exporter';
+        const startBtn = document.getElementById('startBtn');
+        const downloadBtn = document.getElementById('downloadBtn');
+        const statusBadge = document.getElementById('statusBadge');
+        const statusDetails = document.getElementById('statusDetails');
+        const pageCountEl = document.getElementById('pageCount');
+        const jobMeta = document.getElementById('jobMeta');
+        const historyBody = document.getElementById('historyBody');
+
+        let currentJobId = null;
+        let currentJobUrl = null;
+        let pollTimer = null;
+        const history = [];
+
+        function setBadge(status, text) {
+            statusBadge.className = 'status-badge ' + status;
+            statusBadge.textContent = text;
+        }
+
+        function resetStatus() {
+            setBadge('info', '尚未开始');
+            statusDetails.textContent = '准备就绪。提交任务后这里将展示实时进度与说明。';
+            pageCountEl.textContent = '—';
+            jobMeta.textContent = '';
+            downloadBtn.disabled = true;
+        }
+
+        function formatTime(date) {
+            return new Intl.DateTimeFormat('zh-CN', {
+                hour12: false,
+                month: '2-digit',
+                day: '2-digit',
+                hour: '2-digit',
+                minute: '2-digit',
+                second: '2-digit'
+            }).format(date);
+        }
+
+        function appendHistory(entry) {
+            history.unshift(entry);
+            renderHistory();
+        }
+
+        function renderHistory() {
+            if (history.length === 0) {
+                historyBody.innerHTML = '<tr><td colspan="5" class="hint">暂无任务，赶快试试看吧！</td></tr>';
+                return;
+            }
+
+            historyBody.innerHTML = history.map(item => `
+                <tr>
+                    <td>${item.time}</td>
+                    <td><a href="${item.url}" target="_blank" rel="noopener">${item.url}</a></td>
+                    <td><span class="pill ${item.statusClass}">${item.statusLabel}</span></td>
+                    <td>${item.pageCount ?? '—'}</td>
+                    <td>
+                        ${item.downloadUrl ? `<a href="#" data-job="${item.jobId}" class="download-link">下载</a>` : '<span class="hint">等待中</span>'}
+                    </td>
+                </tr>
+            `).join('');
+
+            document.querySelectorAll('.download-link').forEach(link => {
+                link.addEventListener('click', async (event) => {
+                    event.preventDefault();
+                    const jobId = event.currentTarget.dataset.job;
+                    await downloadArchive(jobId);
+                });
+            });
+        }
+
+        function updateHistoryEntry(jobId, updates) {
+            const index = history.findIndex(item => item.jobId === jobId);
+            if (index >= 0) {
+                history[index] = { ...history[index], ...updates };
+                renderHistory();
+            }
+        }
+
+        async function startCrawl() {
+            const url = document.getElementById('targetUrl').value.trim();
+            const maxDepth = Number(document.getElementById('maxDepth').value);
+            const maxPages = Number(document.getElementById('maxPages').value);
+            const includeSubdomains = document.getElementById('includeSubdomains').checked;
+            const ignoreSitemap = document.getElementById('ignoreSitemap').checked;
+
+            if (!url) {
+                alert('请先输入要解析的目标网址。');
+                return;
+            }
+
+            resetStatus();
+            setBadge('warning', '提交中...');
+            statusDetails.textContent = '正在创建 Firecrawl 任务，请稍候。';
+            startBtn.disabled = true;
+
+            try {
+                const response = await fetch(`${API_PREFIX}/jobs`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        url,
+                        max_depth: maxDepth,
+                        max_pages: maxPages,
+                        include_subdomains: includeSubdomains,
+                        ignore_sitemap: ignoreSitemap
+                    })
+                });
+
+                if (!response.ok) {
+                    const errorPayload = await response.json().catch(() => ({}));
+                    throw new Error(errorPayload.detail || 'Firecrawl 任务创建失败');
+                }
+
+                const data = await response.json();
+                currentJobId = data.job_id;
+                currentJobUrl = url;
+                setBadge('warning', '已排队');
+                statusDetails.textContent = data.detail || 'Firecrawl 正在排队处理中。';
+                jobMeta.textContent = `任务编号：${currentJobId}`;
+
+                appendHistory({
+                    jobId: currentJobId,
+                    url,
+                    time: formatTime(new Date()),
+                    statusLabel: '排队中',
+                    statusClass: 'warning',
+                    pageCount: null,
+                    downloadUrl: null
+                });
+
+                schedulePolling(data.poll_after_seconds ?? 2.5);
+            } catch (error) {
+                console.error(error);
+                setBadge('danger', '提交失败');
+                statusDetails.textContent = error.message || 'Firecrawl 任务提交失败。';
+                startBtn.disabled = false;
+            }
+        }
+
+        function schedulePolling(intervalSeconds) {
+            if (pollTimer) {
+                clearInterval(pollTimer);
+            }
+
+            pollTimer = setInterval(() => pollStatus(), Math.max(intervalSeconds * 1000, 2000));
+        }
+
+        async function pollStatus() {
+            if (!currentJobId) {
+                clearInterval(pollTimer);
+                pollTimer = null;
+                return;
+            }
+
+            try {
+                const response = await fetch(`${API_PREFIX}/jobs/${currentJobId}`);
+                if (!response.ok) {
+                    throw new Error('查询任务状态失败');
+                }
+
+                const data = await response.json();
+                const normalized = data.status;
+                const firecrawlStatus = data.firecrawl_status;
+                const pages = data.page_count ?? null;
+
+                pageCountEl.textContent = pages ? `${pages} 个页面` : '—';
+                jobMeta.textContent = `任务编号：${data.job_id}${data.last_updated ? ` ｜ Firecrawl 更新时间：${data.last_updated}` : ''}`;
+                statusDetails.textContent = data.detail || `Firecrawl 状态：${firecrawlStatus}`;
+
+                let statusLabel = '进行中';
+                let statusClass = 'warning';
+
+                if (normalized === 'queued') {
+                    setBadge('warning', '排队中');
+                    statusLabel = '排队中';
+                } else if (normalized === 'running') {
+                    setBadge('warning', '解析中');
+                    statusLabel = '解析中';
+                } else if (normalized === 'completed') {
+                    setBadge('success', '已完成');
+                    statusLabel = '已完成';
+                    statusClass = 'success';
+                    downloadBtn.disabled = false;
+                    clearInterval(pollTimer);
+                    pollTimer = null;
+                    startBtn.disabled = false;
+                } else if (normalized === 'failed') {
+                    setBadge('danger', '失败');
+                    statusLabel = '失败';
+                    statusClass = 'danger';
+                    downloadBtn.disabled = true;
+                    clearInterval(pollTimer);
+                    pollTimer = null;
+                    startBtn.disabled = false;
+                } else {
+                    setBadge('info', firecrawlStatus);
+                    statusLabel = firecrawlStatus;
+                    statusClass = 'info';
+                }
+
+                updateHistoryEntry(currentJobId, {
+                    statusLabel,
+                    statusClass,
+                    pageCount: pages,
+                    downloadUrl: data.download_url || null
+                });
+            } catch (error) {
+                console.error(error);
+                setBadge('danger', '状态异常');
+                statusDetails.textContent = error.message || '获取任务状态失败，请稍后重试。';
+                startBtn.disabled = false;
+                clearInterval(pollTimer);
+                pollTimer = null;
+            }
+        }
+
+        async function downloadArchive(jobId = currentJobId) {
+            if (!jobId) {
+                alert('暂无可下载的任务。');
+                return;
+            }
+
+            try {
+                const response = await fetch(`${API_PREFIX}/jobs/${jobId}/download`);
+                if (!response.ok) {
+                    const payload = await response.json().catch(() => ({}));
+                    throw new Error(payload.detail || '下载失败，请稍后再试。');
+                }
+
+                const blob = await response.blob();
+                const disposition = response.headers.get('Content-Disposition') || '';
+                const match = disposition.match(/filename=([^;]+)/i);
+                const filename = match ? decodeURIComponent(match[1]) : `firecrawl-export-${Date.now()}.zip`;
+
+                const url = window.URL.createObjectURL(blob);
+                const link = document.createElement('a');
+                link.href = url;
+                link.download = filename.replaceAll('"', '');
+                document.body.appendChild(link);
+                link.click();
+                link.remove();
+                window.URL.revokeObjectURL(url);
+            } catch (error) {
+                alert(error.message);
+            }
+        }
+
+        startBtn.addEventListener('click', (event) => {
+            event.preventDefault();
+            startCrawl();
+        });
+
+        downloadBtn.addEventListener('click', async (event) => {
+            event.preventDefault();
+            await downloadArchive();
+        });
+
+        resetStatus();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- restore the Firecrawl exporter backend module and document the feature in the README
- re-register the exporter routes and feature card so the tool is accessible from the dashboard
- refine the hero headline and description to present the Firecrawl exporter in a more productized tone

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68e8c8cecc308332b052ced3bb2cfd01